### PR TITLE
[feat] #10 Database로부터 Default 결제수단을 받아와서 사용 할 수 있도록 연결

### DIFF
--- a/FE/src/api/defaultPaymentMethod.ts
+++ b/FE/src/api/defaultPaymentMethod.ts
@@ -1,0 +1,6 @@
+import { getFetch } from '../service/fetch';
+
+export const getDefaultMethods = () => {
+  const data = getFetch('http://localhost:3000/api/defaultPaymentMethod');
+  return data;
+};

--- a/FE/src/pages/PaymentMethod/index.tsx
+++ b/FE/src/pages/PaymentMethod/index.tsx
@@ -1,24 +1,22 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 
 import Modal from '../../components/PaymentMethod/Modal';
 import MenuBar from '../../components/Common/MenuBar';
 import styles from './paymentPage.module.scss';
+import { getDefaultMethods } from '../../api/defaultPaymentMethod';
 
 export default function PaymentMethod() {
   const [modal, setModal] = useState(true);
+  const [defaultMethod, setDefaultMethod] = useState([]);
 
-  // 백엔드에서 받아올 default 결제수단.
-  const defaultMethod = [
-    { name: 'KB 국민카드', color: 'hsla(0, 100%, 50%, 0.93)' },
-    { name: 'Kakao ', color: 'hsla(40, 100%, 50%, 0.93)' },
-    { name: 'SC 제일은행', color: 'hsla(80, 100%, 50%, 0.93)' },
-    { name: 'Naver ', color: 'hsla(120, 100%, 50%, 0.93)' },
-    { name: 'KEB Hana ', color: 'hsla(160, 100%, 50%, 0.93)' },
-    { name: 'WOORI Card', color: 'hsla(200, 100%, 50%, 0.93)' },
-    { name: 'Samsung', color: 'hsla(240, 100%, 50%, 0.93)' },
-    { name: 'Hyundai', color: 'hsla(280, 100%, 50%, 0.93)' },
-    { name: 'BC Card', color: 'hsla(320, 100%, 50%, 0.93)' },
-  ];
+  const getData = useCallback(async () => {
+    const datas = await getDefaultMethods();
+    setDefaultMethod(datas);
+  }, []);
+
+  useEffect(() => {
+    getData();
+  }, []);
 
   return (
     <div className={styles.wrapper}>

--- a/FE/src/service/fetch.ts
+++ b/FE/src/service/fetch.ts
@@ -1,0 +1,46 @@
+export const getFetch = async query => {
+  const response = await fetch(`${query}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json;',
+    },
+  });
+  const json = response.json();
+  return json;
+};
+
+export const postFetch = async (query, body) => {
+  const response = await fetch(`${query}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = response.json();
+  return json;
+};
+
+export const updateFetch = async (query, body) => {
+  const response = await fetch(`${query}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = response.json();
+  return json;
+};
+
+export const deleteFetch = async (query, body) => {
+  const response = await fetch(`${query}`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+  const json = response.json();
+  return json;
+};


### PR DESCRIPTION
### 📕 Issue Number

Closes #10 

<br/>

### 📙 작업 내역

사용자의 결제수단과는 별도로 Add버튼을 눌렀을 때 보이는 Default 결제수단에 관한 API이므로, 사용자 결제수단이 완성되면 추가로 연동해야 할 것 같습니다 !

> 구현 내용 및 작업 했던 내역

- [x] 데이터베이스에 있는 Default  결제수단 선택지를 front에 연동하는 작업을 하였습니다.
- [x] service폴더에 CRUD에 대한 fetch를 추상화 하여 사용할 수 있도록 하였습니다.
 - 기본적인 네트워크 통신에 대한 추상화이므로, 헤더에 옵션을 추가해야 하는등의 상황에는 별도로 사용해도 괜찮을거 같습니다 !
- [x] 네트워크 통신 로직을 api 폴더에 넣고, 컴포넌트에서는 결과만 받아서 사용하도록 하였습니다. 
(api를 따로 관리하는것의 좋은점에 대해 더 생각해봐야할 것 같습니다 !)
- [x] useCallback을 통해 함수를 재활용할 수 있도록 하였고, 이렇게 정의한 함수를 useEffect에서 사용하였습니다.
(단, 의존성 배열에 넣어주지 않았는데 Default 선택지를 초기에 셋팅하고 부터는 변경사항이 전혀 없을거라 판단해서입니다! )


<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
