### PR TITLE
[FE] 가계부 내역 레이아웃

### DIFF
--- a/FE/src/transaction/components/date/date.module.scss
+++ b/FE/src/transaction/components/date/date.module.scss
@@ -1,0 +1,10 @@
+.wrapper {
+  width: 30%;
+  height: 150px;
+  background-color: green;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/FE/src/transaction/components/date/date.tsx
+++ b/FE/src/transaction/components/date/date.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './date.module.scss';
+
+import Year from './year/year';
+import Month from './month/month';
+
+const Date = props => {
+  return (
+    <div className={styles.wrapper}>
+      <Year />
+      <Month />
+    </div>
+  );
+};
+
+export default Date;

--- a/FE/src/transaction/components/date/month/month.module.scss
+++ b/FE/src/transaction/components/date/month/month.module.scss
@@ -1,0 +1,20 @@
+.month__wrapper {
+  width: 100%;
+  height: 75px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+}
+
+.month {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  font-size: 36px;
+  font-weight: 700;
+  display: flex;
+  justify-content: center;
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/FE/src/transaction/components/date/month/month.tsx
+++ b/FE/src/transaction/components/date/month/month.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './month.module.scss';
+
+const Month = props => {
+  const month = new Date().getMonth().toString();
+
+  return (
+    <div className={styles.month__wrapper}>
+      <div className={styles.month}>{}</div>
+      <div className={styles.month}>{month}</div>
+      <div className={styles.month}>{}</div>
+    </div>
+  );
+};
+
+export default Month;

--- a/FE/src/transaction/components/date/year/year.module.scss
+++ b/FE/src/transaction/components/date/year/year.module.scss
@@ -1,0 +1,20 @@
+.year__wrapper {
+  width: 100%;
+  height: 75px;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+}
+
+.year {
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  font-size: 44px;
+  font-weight: 700;
+  display: flex;
+  justify-content: center;
+  &:hover {
+    cursor: pointer;
+  }
+}

--- a/FE/src/transaction/components/date/year/year.tsx
+++ b/FE/src/transaction/components/date/year/year.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './year.module.scss';
+
+const Year = props => {
+  const year = new Date().getFullYear();
+
+  return (
+    <div className={styles.year__wrapper}>
+      <div className={styles.year}>{year - 1}</div>
+      <div className={styles.year}>{year}</div>
+      <div className={styles.year}>{year + 1}</div>
+    </div>
+  );
+};
+
+export default Year;

--- a/FE/src/transaction/components/list/filter/listfilter.modules.scss
+++ b/FE/src/transaction/components/list/filter/listfilter.modules.scss
@@ -1,0 +1,77 @@
+.container {
+  width: 100%;
+  height: 100px;
+
+  .inoutFilter {
+    width: 100%;
+    height: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    div {
+      width: 40%;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      font-weight: 600;
+      font-size: 24px;
+    }
+    div:first-child {
+      input:checked + label {
+        background-color: rgb(30, 200, 0);
+        color: white;
+      }
+      label {
+        width: auto;
+        padding: 10px 15px;
+        height: 50px;
+        line-height: 30px;
+        border: 3px solid rgb(30, 200, 0);
+        color: rgb(30, 200, 0);
+        border-radius: 10px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+    div:last-child {
+      input:checked + label {
+        background-color: #e84118;
+        color: white;
+      }
+      label {
+        width: auto;
+        padding: 10px 15px;
+        height: 50px;
+        line-height: 30px;
+        border: 3px solid #e84118;
+        color: #e84118;
+        border-radius: 10px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+    input {
+      display: none;
+    }
+    div {
+      input,
+      label {
+        cursor: pointer;
+      }
+    }
+  }
+  .categoryFilter {
+    width: 100%;
+    height: 50px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    label {
+      width: 70px;
+      cursor: pointer;
+    }
+  }
+}

--- a/FE/src/transaction/components/list/filter/listfilter.tsx
+++ b/FE/src/transaction/components/list/filter/listfilter.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import styles from './listfilter.modules.scss';
+
+const Filter = props => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.inoutFilter}>
+        <div>
+          <input type="radio" name="inout" id="in" />
+          <label htmlFor="in">
+            <span>+ 0</span>
+          </label>
+        </div>
+        <div>
+          <input type="radio" name="inout" id="out" />
+          <label htmlFor="out">
+            <span>- 0</span>
+          </label>
+        </div>
+      </div>
+      <div className={styles.categoryFilter}>
+        <label htmlFor="shopping">
+          <input type="checkbox" id="shopping" />
+          쇼핑
+        </label>
+        <label htmlFor="movie">
+          <input type="checkbox" id="movie" />
+          영화
+        </label>
+        <label htmlFor="music">
+          <input type="checkbox" id="music" />
+          음악
+        </label>
+        <label htmlFor="food">
+          <input type="checkbox" id="food" />
+          음식
+        </label>
+        <label htmlFor="any">
+          <input type="checkbox" id="any" />
+          기타
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default Filter;

--- a/FE/src/transaction/components/list/listcontainer.module.scss
+++ b/FE/src/transaction/components/list/listcontainer.module.scss
@@ -1,0 +1,10 @@
+.container {
+  width: 50%;
+  height: 100%;
+  padding: 10px 5px;
+  background-color: white;
+  border: 1px dotted #cdcdcd;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/FE/src/transaction/components/list/listcontainer.tsx
+++ b/FE/src/transaction/components/list/listcontainer.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import styles from './listcontainer.module.scss';
+
+import Filter from './filter/listfilter';
+import Transactions from './transactions/transactions';
+
+const ListContainer = props => {
+  return (
+    <div className={styles.container}>
+      <Filter />
+      <Transactions />
+    </div>
+  );
+};
+
+export default ListContainer;

--- a/FE/src/transaction/components/list/transactions/transactions.module.scss
+++ b/FE/src/transaction/components/list/transactions/transactions.module.scss
@@ -1,0 +1,40 @@
+.day {
+  width: 100%;
+  height: auto;
+  background-color: white;
+  border: 1px solid black;
+  box-sizing: border-box;
+  padding: 5px 10px;
+}
+
+.daybar {
+  width: 100%;
+  height: 30px;
+  margin-bottom: 10px;
+  border-bottom: 1px solid black;
+}
+
+.transaction {
+  width: 100%;
+  height: 50px;
+  background-color: #dcdcdc;
+  border: 1px dotted black;
+  box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0px 10px;
+  .category {
+    width: 20%;
+  }
+  .description {
+    width: 40%;
+  }
+  .payment {
+    width: 20%;
+  }
+  .cost {
+    width: 20%;
+    text-align: end;
+  }
+}

--- a/FE/src/transaction/components/list/transactions/transactions.tsx
+++ b/FE/src/transaction/components/list/transactions/transactions.tsx
@@ -1,0 +1,55 @@
+/* eslint-disable react/jsx-one-expression-per-line */
+import React from 'react';
+import styles from './transactions.module.scss';
+
+const makeContent = (category: string, desc: string, payment: string, cost: number) => {
+  return (
+    <div className={styles.transaction}>
+      <span className={styles.category}>{category}</span>
+      <span className={styles.description}>{desc}</span>
+      <span className={styles.payment}>{payment}</span>
+      <span className={styles.cost}>{cost}</span>
+    </div>
+  );
+};
+
+const makeTransactions = () => {
+  // axios로 비동기 처리
+  const transactions = [
+    { day: 1, category: '뷰티', description: '미용실', payment: '신한카드', cost: 14000 },
+    { day: 1, category: '뷰티', description: '미용실', payment: '신한카드', cost: 1 },
+    { day: 1, category: '뷰티', description: '미용실', payment: '신한카드', cost: 2 },
+    { day: 1, category: '뷰티', description: '미용실', payment: '신한카드', cost: 3 },
+    { day: 1, category: '뷰티', description: '미용실', payment: '신한카드', cost: 4 },
+    { day: 2, category: '밥', description: '김선생', payment: '신한카드', cost: 5 },
+    { day: 3, category: '쇼핑', description: '무신사', payment: '신한카드', cost: 163 },
+    { day: 3, category: '쇼핑', description: '나이키', payment: '신한카드', cost: 421 },
+    { day: 4, category: '저금', description: '카뱅', payment: '신한카드', cost: 123 },
+    { day: 4, category: '저금', description: '주택청약', payment: '신한카드', cost: 231 },
+    { day: 15, category: '쇼핑', description: '나이키', payment: '신한카드', cost: 22 },
+  ];
+
+  const days = transactions.map(value => value.day);
+  const daysArr = Array.from(new Set<number>(days)).reverse();
+
+  return (
+    <>
+      {daysArr.map(day => {
+        return (
+          <div className={styles.day}>
+            <div className={styles.daybar}> {day} 일</div>
+            {transactions
+              .filter(t => t.day === day)
+              .map(t => makeContent(t.category, t.description, t.payment, t.cost))}
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+const Transactions = () => {
+  return <>{makeTransactions()}</>;
+};
+
+export default Transactions;

--- a/FE/src/transaction/components/menubar/menubar.module.scss
+++ b/FE/src/transaction/components/menubar/menubar.module.scss
@@ -1,0 +1,5 @@
+div {
+  width: 30%;
+  height: 50px;
+  background-color: white;
+}

--- a/FE/src/transaction/components/menubar/menubar.tsx
+++ b/FE/src/transaction/components/menubar/menubar.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import './menubar.module.scss';
+
+const Menubar = props => {
+  return <div>메뉴바</div>;
+};
+
+export default Menubar;

--- a/FE/src/transaction/transaction.module.scss
+++ b/FE/src/transaction/transaction.module.scss
@@ -1,0 +1,7 @@
+.container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}

--- a/FE/src/transaction/transaction.tsx
+++ b/FE/src/transaction/transaction.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from './transaction.module.scss';
+
+import Date from './components/date/date';
+import Menubar from './components/menubar/menubar';
+import ListContainer from './components/list/listcontainer';
+
+const TransactionComponent = props => {
+  return (
+    <>
+      <div className={styles.container}>
+        <Menubar />
+        <Date />
+        <ListContainer />
+      </div>
+    </>
+  );
+};
+
+export default TransactionComponent;


### PR DESCRIPTION
### 📕 Issue Number

가계부 내역 화면 layout
트랜잭션은 X
Close #27 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 가계부 내역 레이아웃, 확인할 수 있는 css 짜기
![image](https://user-images.githubusercontent.com/28282793/100300643-d3a2c280-2fd9-11eb-9b31-45c478790ac1.png)
- [ ] 가계부 내역 인터랙션
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
