### PR TITLE
Payment method modal fix

### DIFF
--- a/FE/src/api/defaultPaymentMethod.ts
+++ b/FE/src/api/defaultPaymentMethod.ts
@@ -1,6 +1,6 @@
 import { getFetch } from '../service/fetch';
 
 export const getDefaultMethods = () => {
-  const data = getFetch('http://localhost:3000/api/defaultPaymentMethod');
+  const data = getFetch(`${process.env.SERVER_URL}/api/defaultPaymentMethod`);
   return data;
 };

--- a/FE/src/components/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/calendar.scss
@@ -1,12 +1,10 @@
 .calendar-container {
-  position: fixed;
-  top: 12em;
-  // left: 50%;
+  margin-top: 10em;
   width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  // transform: translateX(-50%);
+
   .my-calendar {
     width: 100%;
     margin: 30px;

--- a/FE/src/components/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/calendar.scss
@@ -1,5 +1,5 @@
 .calendar-container {
-  position: absolute;
+  position: fixed;
   top: 12em;
   // left: 50%;
   width: 100%;

--- a/FE/src/components/Common/MenuBar/menubar.module.scss
+++ b/FE/src/components/Common/MenuBar/menubar.module.scss
@@ -3,7 +3,7 @@
   background-color: #222;
   width: 100%;
   padding: 2em 0;
-
+  z-index: 2;
   .buttons {
     display: flex;
     justify-content: center;

--- a/FE/src/components/PaymentMethod/CardContainer/cardContainer.module.scss
+++ b/FE/src/components/PaymentMethod/CardContainer/cardContainer.module.scss
@@ -1,5 +1,5 @@
 .container {
-  position: absolute;
+  position: fixed;
   top: 0;
   right: 0;
   width: 100%;

--- a/FE/src/pages/Calendar/index.tsx
+++ b/FE/src/pages/Calendar/index.tsx
@@ -7,14 +7,16 @@ import styles from './calendar.module.scss';
 import useDefaultPayment from '../../service/useDefaultPayment';
 
 export default function CalendarPage() {
-  const [modal, setModal] = useState(false);
+  const [paymentMethodModal, setPaymentMethodModal] = useState(false);
   const defaultMethod = useDefaultPayment();
 
   return (
     <div className={styles.wrapper}>
-      <MenuBar setModal={setModal} pageType="calendar" />
+      <MenuBar setModal={setPaymentMethodModal} pageType="calendar" />
       <Calendar />
-      {modal && <Modal setModal={setModal} defaultMethod={defaultMethod} />}
+      {paymentMethodModal && (
+        <Modal setModal={setPaymentMethodModal} defaultMethod={defaultMethod} />
+      )}
     </div>
   );
 }

--- a/FE/src/pages/Calendar/index.tsx
+++ b/FE/src/pages/Calendar/index.tsx
@@ -4,22 +4,11 @@ import Modal from '../../components/PaymentMethod/Modal';
 import MenuBar from '../../components/Common/MenuBar';
 import Calendar from '../../components/Calendar';
 import styles from './calendar.module.scss';
-import { useRootData } from '../../store/PaymentMethod/paymentMethodHook';
+import useDefaultPayment from '../../service/useDefaultPayment';
 
 export default function CalendarPage() {
   const [modal, setModal] = useState(false);
-  const [defaultMethod, setDefaultMethod] = useState([]);
-
-  const storeData = useRootData(store => store.defaultMethods);
-
-  const getDefaultMethod = async () => {
-    const datas = await storeData;
-    setDefaultMethod(datas);
-  };
-
-  useEffect(() => {
-    getDefaultMethod();
-  }, []);
+  const defaultMethod = useDefaultPayment();
 
   return (
     <div className={styles.wrapper}>

--- a/FE/src/pages/Calendar/index.tsx
+++ b/FE/src/pages/Calendar/index.tsx
@@ -4,19 +4,21 @@ import Modal from '../../components/PaymentMethod/Modal';
 import MenuBar from '../../components/Common/MenuBar';
 import Calendar from '../../components/Calendar';
 import styles from './calendar.module.scss';
-import { getDefaultMethods } from '../../api/defaultPaymentMethod';
+import { useRootData } from '../../store/PaymentMethod/paymentMethodHook';
 
 export default function CalendarPage() {
   const [modal, setModal] = useState(false);
   const [defaultMethod, setDefaultMethod] = useState([]);
 
-  const getData = async () => {
-    const datas = await getDefaultMethods();
+  const storeData = useRootData(store => store.defaultMethods);
+
+  const getDefaultMethod = async () => {
+    const datas = await storeData;
     setDefaultMethod(datas);
   };
 
   useEffect(() => {
-    getData();
+    getDefaultMethod();
   }, []);
 
   return (

--- a/FE/src/pages/defaultTemplate/index.tsx
+++ b/FE/src/pages/defaultTemplate/index.tsx
@@ -2,22 +2,12 @@ import React, { useState, useEffect, useCallback } from 'react';
 
 import Modal from '../../components/PaymentMethod/Modal';
 import MenuBar from '../../components/Common/MenuBar';
-
 import styles from './paymentPage.module.scss';
-import { getDefaultMethods } from '../../api/defaultPaymentMethod';
+import useDefaultPayment from '../../service/useDefaultPayment';
 
 export default function DefaultTemplate() {
   const [modal, setModal] = useState(false);
-  const [defaultMethod, setDefaultMethod] = useState([]);
-
-  const getData = async () => {
-    const datas = await getDefaultMethods();
-    setDefaultMethod(datas);
-  };
-
-  useEffect(() => {
-    getData();
-  }, []);
+  const defaultMethod = useDefaultPayment();
 
   return (
     <div className={styles.wrapper}>

--- a/FE/src/pages/transaction/index.tsx
+++ b/FE/src/pages/transaction/index.tsx
@@ -4,26 +4,18 @@ import styles from './transaction.module.scss';
 import Modal from '../../components/PaymentMethod/Modal';
 import Menubar from '../../components/Common/MenuBar';
 import ListContainer from '../../components/transaction/list/listcontainer';
-import { getDefaultMethods } from '../../api/defaultPaymentMethod';
+import useDefaultPayment from '../../service/useDefaultPayment';
 
 const TransactionComponent = props => {
-  const [modal, setModal] = useState(false);
-  const [defaultMethod, setDefaultMethod] = useState([]);
-
-  const getData = async () => {
-    const datas = await getDefaultMethods();
-    setDefaultMethod(datas);
-  };
-
-  useEffect(() => {
-    getData();
-  }, []);
-
+  const [paymentMethodModal, setPaymentMethodModal] = useState(false);
+  const defaultMethod = useDefaultPayment();
   return (
     <div className={styles.container}>
-      <Menubar setModal={setModal} pageType="transaction" />
+      <Menubar setModal={setPaymentMethodModal} pageType="transaction" />
       <ListContainer />
-      {modal && <Modal setModal={setModal} defaultMethod={defaultMethod} />}
+      {paymentMethodModal && (
+        <Modal setModal={setPaymentMethodModal} defaultMethod={defaultMethod} />
+      )}
     </div>
   );
 };

--- a/FE/src/service/useDefaultPayment.ts
+++ b/FE/src/service/useDefaultPayment.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+import { useRootData } from '../store/PaymentMethod/paymentMethodHook';
+
+const useDefaultPayment = () => {
+  const [defaultMethod, setDefaultMethod] = useState([]);
+  const storeData = useRootData(store => store.defaultMethods);
+
+  const getDefaultMethod = async () => {
+    const datas = await storeData;
+    setDefaultMethod(datas);
+  };
+
+  useEffect(() => {
+    getDefaultMethod();
+  }, []);
+
+  return defaultMethod;
+};
+
+export default useDefaultPayment;

--- a/FE/src/store/PaymentMethod/paymentMethodStore.ts
+++ b/FE/src/store/PaymentMethod/paymentMethodStore.ts
@@ -1,5 +1,8 @@
+import { getDefaultMethods } from '../../api/defaultPaymentMethod';
+
 export const createStore = () => {
   const store = {
+    defaultMethods: getDefaultMethods(),
     addTemplateData: { name: '', color: '' },
     paymentMethod: [
       {


### PR DESCRIPTION
### 📕 Issue Number

Close #
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] default payment method를 가져오는 네트워크 통신을 한번만 하고, 전역 데이터에 넣도록 수정
- [x] payment method 관리 modal을 사용하는 페이지에서 공통으로 사용할 수 있는 custom hook 작성
- [x] 화면 크기에 따라 calendar UI가 깨지던 것 수정
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
