### PR TITLE
Pie chart svg

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -1554,6 +1554,12 @@
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+      "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
+      "dev": true
+    },
     "@types/webpack": {
       "version": "4.41.25",
       "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.25.tgz",
@@ -8937,6 +8943,12 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -9566,6 +9578,14 @@
         "faye-websocket": "^0.10.0",
         "uuid": "^3.4.0",
         "websocket-driver": "0.6.5"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
+        }
       }
     },
     "sockjs-client": {
@@ -11064,10 +11084,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",
@@ -11656,6 +11675,12 @@
           "version": "3.2.4",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
           "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }

--- a/FE/package.json
+++ b/FE/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "sass": "^1.29.0",
-    "url-loader": "^4.1.1"
+    "url-loader": "^4.1.1",
+    "uuid": "^8.3.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",
@@ -32,6 +33,7 @@
     "@types/react-dom": "^16.9.9",
     "@types/react-router-dom": "^5.1.6",
     "@types/sass": "^1.16.0",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",
     "@typescript-eslint/parser": "4.0.1",
     "babel-loader": "^8.1.0",

--- a/FE/src/app.tsx
+++ b/FE/src/app.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 
 import PaymentProvider from './store/PaymentMethod/paymentMethodContext';
 import DateInfoProvider from './store/DateInfo/dateInfoContext';
+import TransactionInfoProvider from './store/TransactionData/transactionDataContext';
 import './app.scss';
 
 import DefaultTemplate from './pages/DefaultTemplate';
@@ -10,21 +11,25 @@ import CalendarPage from './pages/Calendar';
 import LoginPage from './pages/Login';
 import TransactionPage from './pages/transaction';
 import GithubLoginProcess from './pages/Login/GithubLoginProcess';
+import ChartPage from './pages/Chart';
 
 const App = () => {
   return (
     <DateInfoProvider>
-      <PaymentProvider>
-        <Router>
-          <Switch>
-            <Route exact path="/" component={DefaultTemplate} />
-            <Route exact path="/login" component={LoginPage} />
-            <Route exact path="/auth/github" component={GithubLoginProcess} />
-            <Route exact path="/calendar" component={CalendarPage} />
-            <Route exact path="/transaction" component={TransactionPage} />
-          </Switch>
-        </Router>
-      </PaymentProvider>
+      <TransactionInfoProvider>
+        <PaymentProvider>
+          <Router>
+            <Switch>
+              <Route exact path="/" component={DefaultTemplate} />
+              <Route exact path="/login" component={LoginPage} />
+              <Route exact path="/auth/github" component={GithubLoginProcess} />
+              <Route exact path="/calendar" component={CalendarPage} />
+              <Route exact path="/transaction" component={TransactionPage} />
+              <Route exact path="/chart" component={ChartPage} />
+            </Switch>
+          </Router>
+        </PaymentProvider>
+      </TransactionInfoProvider>
     </DateInfoProvider>
   );
 };

--- a/FE/src/components/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/calendar.scss
@@ -1,5 +1,4 @@
 .calendar-container {
-  margin-top: 10em;
   width: 100%;
   display: flex;
   justify-content: center;

--- a/FE/src/components/CategoryChart/PieChart/index.tsx
+++ b/FE/src/components/CategoryChart/PieChart/index.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+import { v4 } from 'uuid';
+import './pieChart.scss';
+
+export default function PieChart({ chartInfo, refArr }) {
+  const colors = ['#ff9aa2', '#ffefb9', '#ffdac1', '#ffb7b2'];
+
+  const drawAnimation = () => {
+    if (chartInfo.length !== 0) {
+      refArr.forEach((_, i) => {
+        const donut = refArr[i].current;
+        const deg = 3.6 * (100 - Number(donut.dataset.per));
+        const r = Number(donut.dataset.radius);
+        donut.style.strokeDasharray = r * 3.141592 * 2;
+        donut.style.strokeDashoffset = r * 3.141592 * 2;
+        donut.style.setProperty('--result', 2 * 3.141592 * r * (deg / 360));
+      });
+    }
+  };
+
+  useEffect(() => {
+    drawAnimation();
+  }, [chartInfo, drawAnimation]);
+
+  return (
+    <>
+      {chartInfo.map((el, i) => {
+        return (
+          <svg key={v4()} className="s_donut" width="300" height="300">
+            <circle
+              ref={refArr[i]}
+              className="donut"
+              cx="150"
+              cy="150"
+              r="125"
+              data-radius="125"
+              stroke={`${colors[i]}`}
+              strokeDasharray="1"
+              strokeDashoffset="0"
+              data-per={`${el.percent}`}
+              transform={`rotate(${el.startPoint} 150 150)`}
+            />
+            <text className="txt" y="150" transform="translate(150)">
+              <tspan x="0" textAnchor="middle">
+                Statistics
+              </tspan>
+            </text>
+          </svg>
+        );
+      })}
+    </>
+  );
+}

--- a/FE/src/components/CategoryChart/PieChart/index.tsx
+++ b/FE/src/components/CategoryChart/PieChart/index.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect } from 'react';
 import { v4 } from 'uuid';
+import ChartColorCollections from '../../../util/chartColorCollection';
 import './pieChart.scss';
 
 export default function PieChart({ chartInfo, refArr }) {
-  const colors = ['#ff9aa2', '#ffefb9', '#ffdac1', '#ffb7b2'];
-
   const drawAnimation = () => {
     if (chartInfo.length !== 0) {
       refArr.forEach((_, i) => {
@@ -34,7 +33,7 @@ export default function PieChart({ chartInfo, refArr }) {
               cy="150"
               r="125"
               data-radius="125"
-              stroke={`${colors[i]}`}
+              stroke={`${ChartColorCollections[i]}`}
               strokeDasharray="1"
               strokeDashoffset="0"
               data-per={`${el.percent}`}

--- a/FE/src/components/CategoryChart/PieChart/pieChart.scss
+++ b/FE/src/components/CategoryChart/PieChart/pieChart.scss
@@ -1,0 +1,40 @@
+:root {
+  --result: 0;
+}
+
+.s_donut {
+  position: absolute;
+  left: 20%;
+  top: 45%;
+  text-align: center;
+
+  .donut {
+    stroke-width: 50;
+    fill: transparent;
+    stroke-dasharray: var(--l);
+    stroke-dashoffset: var(--l);
+    animation: drawDonut 1.5s forwards;
+    animation-iteration-count: 1;
+    @keyframes drawDonut {
+      0% {
+        opacity: 0;
+      }
+      100% {
+        opacity: 1;
+        stroke-dashoffset: var(--result);
+      }
+    }
+  }
+  .txt {
+    animation: twinkle 1.5s forwards;
+    animation-iteration-count: 1;
+    @keyframes twinkle {
+      0% {
+        opacity: 0;
+      }
+      50% {
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/FE/src/components/CategoryChart/TableChart/index.tsx
+++ b/FE/src/components/CategoryChart/TableChart/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { v4 } from 'uuid';
+import './tableChart.scss';
+
+export default function TableChart({ chartInfo }) {
+  const colors = ['#ff9aa2', '#ffefb9', '#ffdac1', '#ffb7b2'];
+  return (
+    <div className="pie__table">
+      {chartInfo &&
+        chartInfo.map((el, i) => (
+          <div className="stat__unit" key={v4()}>
+            <span className="stat__category">{el.category}</span>
+            <span className="stat__percent">{Math.floor(el.percent)}%</span>
+            <span className="stat__background">
+              <span
+                className="stat__color"
+                style={{
+                  display: 'inline-block',
+                  width: `${Math.floor(el.percent)}%`,
+                  height: '20px',
+                  backgroundColor: `${colors[i]}`,
+                }}
+              />
+            </span>
+            <span className="stat__price">{el.cost}원</span>
+          </div>
+        ))}
+    </div>
+  );
+}

--- a/FE/src/components/CategoryChart/TableChart/index.tsx
+++ b/FE/src/components/CategoryChart/TableChart/index.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-
 import { v4 } from 'uuid';
+import ChartColorCollections from '../../../util/chartColorCollection';
 import './tableChart.scss';
 
 export default function TableChart({ chartInfo }) {
-  const colors = ['#ff9aa2', '#ffefb9', '#ffdac1', '#ffb7b2'];
   return (
     <div className="pie__table">
       {chartInfo &&
@@ -19,7 +18,7 @@ export default function TableChart({ chartInfo }) {
                   display: 'inline-block',
                   width: `${Math.floor(el.percent)}%`,
                   height: '20px',
-                  backgroundColor: `${colors[i]}`,
+                  backgroundColor: `${ChartColorCollections[i]}`,
                 }}
               />
             </span>

--- a/FE/src/components/CategoryChart/TableChart/tableChart.scss
+++ b/FE/src/components/CategoryChart/TableChart/tableChart.scss
@@ -1,0 +1,51 @@
+.pie__table {
+  position: absolute;
+  right: 8%;
+  top: 50%;
+
+  width: 40%;
+  height: 50%;
+
+  .stat__unit {
+    border-top: 1px solid rgba(0, 0, 0, 0.3);
+    padding: 15px 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .stat__background {
+    position: absolute;
+    display: inline-block;
+    left: 20%;
+    width: 65%;
+    height: 20px;
+    background-color: rgba(0, 0, 0, 0.05);
+
+    .stat__color {
+      position: absolute;
+      animation: statAnimation 2s;
+    }
+
+    @keyframes statAnimation {
+      from {
+        width: 0;
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
+    }
+  }
+
+  .stat__percent {
+    position: absolute;
+    left: 13%;
+
+    font-weight: bolder;
+  }
+
+  .stat__price {
+    position: absolute;
+    right: 0;
+  }
+}

--- a/FE/src/components/Chart/NavButton/index.tsx
+++ b/FE/src/components/Chart/NavButton/index.tsx
@@ -1,19 +1,9 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 
 import './navButton.scss';
 
 export default function NavButton({ chartType, setChartType }) {
   const buttonRef = useRef();
-
-  const setButton = () => {
-    buttonRef.current.childNodes.forEach(item => {
-      if (item.classList.value === chartType) {
-        item.classList.add('selected');
-      } else {
-        item.classList.remove('selected');
-      }
-    });
-  };
 
   const onClickCategoryButton = () => {
     setChartType('category');
@@ -23,20 +13,20 @@ export default function NavButton({ chartType, setChartType }) {
     setChartType('date');
   };
 
-  useEffect(() => {
-    setButton();
-  }, [chartType]);
-
   return (
     <div ref={buttonRef} className="nav__buttons">
       <button
         type="button"
-        className="category"
+        className={chartType === 'category' ? 'category selected' : 'category'}
         onClick={onClickCategoryButton}
       >
         By Category
       </button>
-      <button type="button" className="date" onClick={onClickDateButton}>
+      <button
+        type="button"
+        className={chartType === 'date' ? 'date selected' : 'date'}
+        onClick={onClickDateButton}
+      >
         By Dates
       </button>
     </div>

--- a/FE/src/components/Chart/NavButton/index.tsx
+++ b/FE/src/components/Chart/NavButton/index.tsx
@@ -1,0 +1,44 @@
+import React, { useRef, useEffect } from 'react';
+
+import './navButton.scss';
+
+export default function NavButton({ chartType, setChartType }) {
+  const buttonRef = useRef();
+
+  const setButton = () => {
+    buttonRef.current.childNodes.forEach(item => {
+      if (item.classList.value === chartType) {
+        item.classList.add('selected');
+      } else {
+        item.classList.remove('selected');
+      }
+    });
+  };
+
+  const onClickCategoryButton = () => {
+    setChartType('category');
+  };
+
+  const onClickDateButton = () => {
+    setChartType('date');
+  };
+
+  useEffect(() => {
+    setButton();
+  }, [chartType]);
+
+  return (
+    <div ref={buttonRef} className="nav__buttons">
+      <button
+        type="button"
+        className="category"
+        onClick={onClickCategoryButton}
+      >
+        By Category
+      </button>
+      <button type="button" className="date" onClick={onClickDateButton}>
+        By Dates
+      </button>
+    </div>
+  );
+}

--- a/FE/src/components/Chart/NavButton/navButton.scss
+++ b/FE/src/components/Chart/NavButton/navButton.scss
@@ -1,0 +1,50 @@
+.nav__buttons {
+  margin-top: 3em;
+  width: 100%;
+  height: 10%;
+  display: flex;
+  justify-content: center;
+
+  .category {
+    width: 15em;
+
+    padding: 0.7em 0;
+    border: none;
+    border-radius: 6px 0 0 6px;
+    font-size: 1.2em;
+    background-color: rgba(0, 0, 0, 0.5);
+    outline: none;
+    color: white;
+    cursor: pointer;
+
+    &.selected {
+      background-color: #222;
+      box-shadow: -2px -2px 5px rgba(0, 0, 0, 0.5),
+        3px 3px 5px rgba(255, 255, 255, 0.07);
+      text-shadow: 0 0 10px rgba(33, 156, 243, 1),
+        0 0 10px rgba(33, 156, 243, 1);
+      color: white;
+    }
+  }
+
+  .date {
+    width: 15em;
+    padding: 0.7em 0;
+    border: none;
+    border-radius: 0 6px 6px 0;
+    font-size: 1.2em;
+    background-color: rgba(0, 0, 0, 0.5);
+    outline: none;
+    color: white;
+    cursor: pointer;
+
+    &.selected {
+      background-color: #222;
+      box-shadow: -2px -2px 5px rgba(0, 0, 0, 0.5),
+        3px 3px 5px rgba(255, 255, 255, 0.07);
+      text-shadow: 0 0 10px rgba(33, 156, 243, 1),
+        0 0 10px rgba(33, 156, 243, 1);
+      color: white;
+    }
+  }
+}

--- a/FE/src/components/Common/MenuBar/index.tsx
+++ b/FE/src/components/Common/MenuBar/index.tsx
@@ -48,17 +48,20 @@ const MenuBar = ({ setModal, pageType }) => {
     setModal(true);
   }, []);
 
-  const setIcon = useCallback(pageType => {
-    if (pageType === 'transaction') {
-      transactionIconRef.current.classList.toggle(styles.checked);
-    }
-    if (pageType === 'calendar') {
-      calIconRef.current.classList.toggle(styles.checked);
-    }
-    if (pageType === 'chart') {
-      chartIconRef.current.classList.toggle(styles.checked);
-    }
-  }, pageType);
+  const setIcon = useCallback(
+    pageType => {
+      if (pageType === 'transaction') {
+        transactionIconRef.current.classList.toggle(styles.checked);
+      }
+      if (pageType === 'calendar') {
+        calIconRef.current.classList.toggle(styles.checked);
+      }
+      if (pageType === 'chart') {
+        chartIconRef.current.classList.toggle(styles.checked);
+      }
+    },
+    [pageType],
+  );
 
   useEffect(() => {
     setIcon(pageType);

--- a/FE/src/components/Common/MenuBar/index.tsx
+++ b/FE/src/components/Common/MenuBar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback, useState } from 'react';
+import React, { useRef, useEffect, useCallback } from 'react';
 
 import { useHistory } from 'react-router-dom';
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
@@ -48,23 +48,7 @@ const MenuBar = ({ setModal, pageType }) => {
     setModal(true);
   }, []);
 
-  const setIcon = useCallback(
-    pageType => {
-      if (pageType === 'transaction') {
-        transactionIconRef.current.classList.toggle(styles.checked);
-      }
-      if (pageType === 'calendar') {
-        calIconRef.current.classList.toggle(styles.checked);
-      }
-      if (pageType === 'chart') {
-        chartIconRef.current.classList.toggle(styles.checked);
-      }
-    },
-    [pageType],
-  );
-
   useEffect(() => {
-    setIcon(pageType);
     setYearMonth(DateInfo.year, DateInfo.month);
   }, [pageType]);
 
@@ -73,7 +57,11 @@ const MenuBar = ({ setModal, pageType }) => {
       <div className={styles.buttons} ref={allBtnRef}>
         <div
           ref={transactionIconRef}
-          className={styles.navBtn}
+          className={
+            pageType === 'transaction'
+              ? `${styles.navBtn} ${styles.checked}`
+              : `${styles.navBtn}`
+          }
           data-type="transaction"
           onClick={onClickIcon}
         >
@@ -81,7 +69,11 @@ const MenuBar = ({ setModal, pageType }) => {
         </div>
         <div
           ref={calIconRef}
-          className={styles.navBtn}
+          className={
+            pageType === 'calendar'
+              ? `${styles.navBtn} ${styles.checked}`
+              : `${styles.navBtn}`
+          }
           data-type="calendar"
           onClick={onClickIcon}
         >
@@ -89,7 +81,11 @@ const MenuBar = ({ setModal, pageType }) => {
         </div>
         <div
           ref={chartIconRef}
-          className={styles.navBtn}
+          className={
+            pageType === 'chart'
+              ? `${styles.navBtn} ${styles.checked}`
+              : `${styles.navBtn}`
+          }
           data-type="chart"
           onClick={onClickIcon}
         >

--- a/FE/src/components/Common/MenuBar/menubar.module.scss
+++ b/FE/src/components/Common/MenuBar/menubar.module.scss
@@ -1,8 +1,8 @@
 .header {
-  position: fixed;
+  // position: fixed;
   background-color: #222;
   width: 100%;
-  padding: 2em 0;
+  padding: 1.5em 0;
   z-index: 2;
   .buttons {
     display: flex;
@@ -11,9 +11,9 @@
 
     .navBtn {
       text-align: center;
-      line-height: 1.8em;
-      width: 1.8em;
-      height: 1.8em;
+      line-height: 1.5em;
+      width: 1.5em;
+      height: 1.5em;
       background-color: transparent;
       border: none;
       outline: none;
@@ -33,11 +33,11 @@
   }
 
   .ctrBox {
-    margin-top: 2em;
+    margin-top: 1.5em;
     font-size: 20px;
     display: flex;
     justify-content: center;
-    gap: 3em;
+    gap: 2em;
     font-weight: 900;
     color: white;
     text-shadow: 0 0 10px rgba(33, 156, 243, 1), 0 0 10px rgba(33, 156, 243, 1);

--- a/FE/src/components/DateChart/LineChart/index.tsx
+++ b/FE/src/components/DateChart/LineChart/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function LineChart(props) {
+  return <h1>line chart</h1>;
+}

--- a/FE/src/components/PaymentMethod/NewMethod/index.tsx
+++ b/FE/src/components/PaymentMethod/NewMethod/index.tsx
@@ -1,6 +1,5 @@
-import React, { useRef, useState, useEffect, useContext } from 'react';
+import React, { useRef, useState } from 'react';
 
-import { paymentContext } from '../../../store/PaymentMethod/paymentMethodContext';
 import { useRootData } from '../../../store/PaymentMethod/paymentMethodHook';
 import './newMethod.scss';
 
@@ -11,7 +10,6 @@ interface SetData {
 export default function NewMethod({
   defaultMethod,
 }: SetData): React.ReactElement {
-  const store = useContext(paymentContext);
   const updateAddTemplate = useRootData(store => store.updateAddTemplate);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const carousel = useRef();

--- a/FE/src/components/transaction/list/listcontainer.module.scss
+++ b/FE/src/components/transaction/list/listcontainer.module.scss
@@ -7,5 +7,9 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 14em;
+  margin-top: 2em;
+
+  &:last-child {
+    margin-bottom: 5em;
+  }
 }

--- a/FE/src/pages/Calendar/calendar.module.scss
+++ b/FE/src/pages/Calendar/calendar.module.scss
@@ -1,7 +1,8 @@
 .wrapper {
-  display: flex;
   width: 100%;
   height: 100%;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
   scroll-behavior: smooth;
 }

--- a/FE/src/pages/Chart/chart.scss
+++ b/FE/src/pages/Chart/chart.scss
@@ -1,0 +1,21 @@
+.chart__wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  .date__charts,
+  .category__charts {
+    width: 100%;
+    height: 100%;
+  }
+
+  .no__data {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+}

--- a/FE/src/pages/Chart/index.tsx
+++ b/FE/src/pages/Chart/index.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+
+import Modal from '../../components/PaymentMethod/Modal';
+import MenuBar from '../../components/Common/MenuBar';
+import NavButton from '../../components/Chart/NavButton';
+import PieChart from '../../components/CategoryChart/PieChart';
+import TableChart from '../../components/CategoryChart/TableChart';
+import LineChart from '../../components/DateChart/LineChart';
+
+import useDefaultPayment from '../../service/useDefaultPayment';
+import useLoginCheck from '../../service/useLoginCheck';
+
+import { useRootData } from '../../store/DateInfo/dateInfoHook';
+import { useTransactionData } from '../../store/TransactionData/transactionInfoHook';
+
+import './chart.scss';
+
+const Chart = props => {
+  useLoginCheck();
+  const [paymentMethodModal, setPaymentMethodModal] = useState(false);
+  const [chartType, setChartType] = useState('category');
+  const defaultMethod = useDefaultPayment();
+
+  const DateInfo = useRootData(store => store.nowCalendarInfo);
+  const ChartInfo = useTransactionData(
+    store => store.getTransactionsForPieChart,
+  );
+
+  const chartInfo = ChartInfo(DateInfo.year, DateInfo.month + 1);
+  const refArr = [];
+  chartInfo.forEach(() => refArr.push(React.createRef()));
+
+  return (
+    <div className="chart__wrapper">
+      <MenuBar setModal={setPaymentMethodModal} pageType="chart" />
+      <NavButton chartType={chartType} setChartType={setChartType} />
+
+      {chartInfo.length === 0 && <div className="no__data">No Data</div>}
+
+      {chartType === 'category' && chartInfo.length !== 0 && (
+        <div className="category__charts">
+          <PieChart chartInfo={chartInfo} refArr={refArr} />
+          <TableChart chartInfo={chartInfo} />
+        </div>
+      )}
+      {chartType === 'date' && chartInfo.length !== 0 && (
+        <div className="date__charts">
+          <LineChart />
+        </div>
+      )}
+      {paymentMethodModal && (
+        <Modal setModal={setPaymentMethodModal} defaultMethod={defaultMethod} />
+      )}
+    </div>
+  );
+};
+
+export default Chart;

--- a/FE/src/store/DateInfo/dateInfoContext.tsx
+++ b/FE/src/store/DateInfo/dateInfoContext.tsx
@@ -1,11 +1,11 @@
 import React, { createContext } from 'react';
-import { useLocalStore } from 'mobx-react';
+import { useLocalObservable } from 'mobx-react';
 import { createStore, TStore } from './dateInfoStore';
 
 export const dateInfoContext = createContext<TStore | null>(null);
 
 export const DateInfoProvider: React.FC = ({ children }) => {
-  const store = useLocalStore(createStore);
+  const store = useLocalObservable(createStore);
 
   return (
     <dateInfoContext.Provider value={store}>

--- a/FE/src/store/PaymentMethod/paymentMethodContext.tsx
+++ b/FE/src/store/PaymentMethod/paymentMethodContext.tsx
@@ -1,11 +1,11 @@
 import React, { createContext } from 'react';
-import { useLocalStore } from 'mobx-react';
+import { useLocalObservable } from 'mobx-react';
 import { createStore, TStore } from './paymentMethodStore';
 
 export const paymentContext = createContext<TStore | null>(null);
 
 export const PaymentProvider: React.FC = ({ children }) => {
-  const store = useLocalStore(createStore);
+  const store = useLocalObservable(createStore);
 
   return (
     <paymentContext.Provider value={store}>{children}</paymentContext.Provider>

--- a/FE/src/store/TransactionData/transactionData.ts
+++ b/FE/src/store/TransactionData/transactionData.ts
@@ -1,0 +1,212 @@
+export const createStore = () => {
+  const store = {
+    accountBook: {
+      _id: 'abcdefg',
+      name: 'test account',
+      description: 'mock account book',
+      category: [
+        {
+          _id: '123456',
+          name: 'shopping',
+          icon: 1,
+        },
+        {
+          _id: '234567',
+          name: 'food',
+          icon: 2,
+        },
+      ],
+      payment: [
+        {
+          _id: 'acacacac',
+          card: 1,
+          description: 'naver',
+        },
+        {
+          _id: 'adadadad',
+          card: 2,
+          description: 'kakao',
+        },
+      ],
+
+      user: [1, 2, 3, 4],
+      transaction: [
+        {
+          _id: 'asdf',
+          content: 'test',
+          type: '지출',
+          cost: 10000,
+          date: '2020-11-29',
+          category: {
+            name: 'shopping',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+        {
+          _id: 'asdf',
+          content: 'test2',
+          type: '지출',
+          cost: 20000,
+          date: '2020-11-29',
+          category: {
+            name: 'food',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+        {
+          _id: 'asdf',
+          content: 'test3',
+          type: '지출',
+          cost: 30000,
+          date: '2020-11-29',
+          category: {
+            name: 'life',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+        {
+          _id: 'asdf',
+          content: 'test4',
+          type: '지출',
+          cost: 40000,
+          date: '2020-11-29',
+          category: {
+            name: 'etc',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+
+        {
+          _id: 'asdf',
+          content: 'test4',
+          type: '지출',
+          cost: 50000,
+          date: '2020-11-29',
+          category: {
+            name: 'etc',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+        {
+          _id: 'asdf',
+          content: 'test4',
+          type: '지출',
+          cost: 1000,
+          date: '2020-10-29',
+          category: {
+            name: 'etc',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+        {
+          _id: 'asdf',
+          content: 'test4',
+          type: '지출',
+          cost: 10000,
+          date: '2020-10-29',
+          category: {
+            name: 'shopping',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+      ],
+    },
+
+    getAllTransactions() {
+      return this.accountBook.transaction;
+    },
+
+    getSpendingTotal(year, month) {
+      let sum = 0;
+      this.accountBook.transaction.forEach(item => {
+        if (
+          item.type === '지출' &&
+          Number(item.date.split('-')[0]) === year &&
+          Number(item.date.split('-')[1]) === month
+        ) {
+          sum += item.cost;
+        }
+      });
+
+      return sum;
+    },
+
+    getTransactionsForPieChart(year: number, month: number) {
+      const chartInfo = {};
+      let accumDeg = 0;
+
+      const datas = this.accountBook.transaction.filter(
+        item =>
+          year === Number(item.date.split('-')[0]) &&
+          month === Number(item.date.split('-')[1]),
+      );
+
+      datas.forEach(item => {
+        if (item.category.name in chartInfo) {
+          chartInfo[item.category.name].cost += item.cost;
+        } else {
+          chartInfo[item.category.name] = {};
+          chartInfo[item.category.name].cost = item.cost;
+        }
+      });
+
+      for (const key in chartInfo) {
+        chartInfo[key].percent =
+          (100 * chartInfo[key].cost) / this.getSpendingTotal(year, month);
+      }
+
+      for (const key in chartInfo) {
+        if (accumDeg === 0) {
+          chartInfo[key].startPoint = 0;
+          accumDeg +=
+            360 * (chartInfo[key].cost / this.getSpendingTotal(year, month));
+        } else {
+          chartInfo[key].startPoint = accumDeg;
+          accumDeg +=
+            360 * (chartInfo[key].cost / this.getSpendingTotal(year, month));
+        }
+      }
+
+      const chartInfoArray = [];
+
+      for (const key in chartInfo) {
+        chartInfo[key].category = key;
+        chartInfoArray.push(chartInfo[key]);
+      }
+
+      return chartInfoArray;
+    },
+  };
+
+  return store;
+};
+
+export type TStore = ReturnType<typeof createStore>;

--- a/FE/src/store/TransactionData/transactionDataContext.tsx
+++ b/FE/src/store/TransactionData/transactionDataContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext } from 'react';
+import { useLocalObservable } from 'mobx-react';
+import { createStore, TStore } from './transactionData';
+
+export const transactionInfoContext = createContext<TStore | null>(null);
+
+export const TransactionInfoProvider: React.FC = ({ children }) => {
+  const store = useLocalObservable(createStore);
+
+  return (
+    <transactionInfoContext.Provider value={store}>
+      {children}
+    </transactionInfoContext.Provider>
+  );
+};
+
+export default TransactionInfoProvider;

--- a/FE/src/store/TransactionData/transactionInfoHook.ts
+++ b/FE/src/store/TransactionData/transactionInfoHook.ts
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useObserver } from 'mobx-react';
+import { transactionInfoContext } from './transactionDataContext';
+import { TStore } from './transactionData';
+
+export const useStoreData = <Selection, ContextData, Store>(
+  context: React.Context<ContextData>,
+  storeSelector: (ContextData: ContextData) => Store,
+  dataSelector: (store: Store) => Selection,
+) => {
+  const value = React.useContext(context);
+  if (!value) throw new Error();
+
+  const store = storeSelector(value);
+  return useObserver(() => {
+    return dataSelector(store);
+  });
+};
+
+export const useTransactionData = <Selection>(
+  dataSelector: (store: TStore) => Selection,
+) =>
+  useStoreData(
+    transactionInfoContext,
+    contextData => contextData!,
+    dataSelector,
+  );

--- a/FE/src/util/chartColorCollection.ts
+++ b/FE/src/util/chartColorCollection.ts
@@ -1,0 +1,14 @@
+const ChartColorCollections = [
+  '#ff5959',
+  '#f98f54',
+  '#f0c350',
+  '#7bca3d',
+  '#56db9b',
+  '#2bcfda',
+  '#5580ef',
+  '#9979f3',
+  '#d879f0',
+  '#ff5fa2',
+];
+
+export default ChartColorCollections;


### PR DESCRIPTION
### 📕 Issue Number

Closes #33 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] Mock Data로 테스트
- Account Book API가 미완성이므로, 설계당시의 account book 모델을 참고하여 Mock Data를 만들어 사용하였습니다.

- [x] 전역데이터 사용 
- pie chart를 그리기 위한 카테고리별 정보를 mobx store로부터 받아와서 그리도록 하였습니다.<br>
  해당 정보에는 카테고리별 이름, 금액, 전체중의 비율, 비율을 반영한 각도가 들어있습니다.
- page컴포넌트에서 받아온 정보를 Pie Chart와 Table Chart에 전달하도록 하였습니다.

- [x] Pie Chart
- 라이브러리 사용 X
- svg를 통해 그리도록 구현하였습니다.
- 자세한 구현방법은 wiki에 정리해 두겠습니다.
- header에서 chart탭 클릭시 기본적으로 설정되어있는 년/월을 참고하여 <br>
  해당 년/월의 카테고리별 pie chart를 그리도록 하였습니다.
- 비율을 반영한 각도를 startPoint로 하여 animation이 동시에 그려지도록 하였습니다.

- [x] Table Chart
- 라이브러리 사용  X
- Pie Chart를 svg circle을 겹치는 방식으로 구현하여 개별 정보를 확인하기 힘들어서 만들게 되었습니다.
- page component로 부터 전달받은 구체적인 데이터들을 시각적으로 보여주었습니다.<br>
  (예 : 카테고리 이름, 퍼센트, 합계 금액 등)
- 애니메이션을 주어 각 카테고리가 전체 중 얼만큼의 비중을 차지하는지 시각적으로 눈에 띄도록 하였습니다.


- [x] 차트용 ColorCollections 
- Pie Chart와 Table Chart가 같은 색상을 사용하여 두 차트간의 정보 매칭을 하기 쉽도록 하였습니다.
- 이쁜 색들을 찾아내야 하는데 ... 우선 빨주노초파남보 순으로 지정해놨습니다.
- 카테고리가 무수히 많아질것을 ( 사실 그럴일은 없겠지만..) 대비하여 색을 많이 넣어두던지, 나머지 연산을 통해 반복 사용되도록 해야 할 것 같습니다.

### 구현모습
![카테고리별차트](https://user-images.githubusercontent.com/49441876/100580135-c7479e00-3328-11eb-97cc-f769149e5180.gif)

파일로 올리면 왜 끊기면서 보이는지 모르겠네요 ㅠㅠ ... <br>
merge되면 한번 확인해보시고 피드백 주시면 반영하겠습니다 !!

<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
