### PR TITLE
Calendar detail info

### DIFF
--- a/FE/src/components/Calendar/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/Calendar/calendar.scss
@@ -1,5 +1,5 @@
-@use '../../styles/values' as *;
-@use '../../styles/mixins' as *;
+@use '../../../styles/values' as *;
+@use '../../../styles/mixins' as *;
 
 .calendar-container {
   width: 100%;

--- a/FE/src/components/Calendar/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/Calendar/calendar.scss
@@ -18,6 +18,7 @@
     cursor: default;
 
     .calendar-box {
+      margin-top: 3em;
       width: 70%;
 
       .cal-table {

--- a/FE/src/components/Calendar/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/Calendar/calendar.scss
@@ -39,11 +39,11 @@
 
           .income__info {
             font-size: 0.8em;
-            color: #54aafc;
+            color: $income-color;
           }
           .spending__info {
             font-size: 0.8em;
-            color: #ee4337;
+            color: $spending-color;
           }
         }
         .day {
@@ -89,7 +89,6 @@
           bottom: 0;
           width: 100%;
           height: 4px;
-          background: #ffc107;
         }
       }
     }

--- a/FE/src/components/Calendar/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/Calendar/calendar.scss
@@ -34,8 +34,17 @@
         td {
           padding: 3px 0;
           height: 80px;
-          font-size: 15px;
-          vertical-align: middle;
+
+          vertical-align: center;
+
+          .income__info {
+            font-size: 0.8em;
+            color: #54aafc;
+          }
+          .spending__info {
+            font-size: 0.8em;
+            color: #ee4337;
+          }
         }
         .day {
           position: relative;

--- a/FE/src/components/Calendar/Calendar/index.tsx
+++ b/FE/src/components/Calendar/Calendar/index.tsx
@@ -4,6 +4,7 @@ import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import { useTransactionData } from '../../../store/TransactionData/transactionInfoHook';
 import CalculateDate from '../../../util/calculateDate';
 import DetailModal from '../DetailModal';
+import CommaMaker from '../../../util/commaForMoney';
 import './calendar.scss';
 
 export default function Calendar() {
@@ -30,8 +31,12 @@ export default function Calendar() {
             date.insertAdjacentHTML(
               'beforeend',
               `
-              <div class="income__info" data-date=${day}>+${info.income}원</div>
-              <div class="spending__info" data-date=${day}>-${info.spending}원</div>
+              <div class="income__info" data-date=${day}>+${CommaMaker(
+                info.income,
+              )}원</div>
+              <div class="spending__info" data-date=${day}>-${CommaMaker(
+                info.spending,
+              )}원</div>
             `,
             );
           }

--- a/FE/src/components/Calendar/Calendar/index.tsx
+++ b/FE/src/components/Calendar/Calendar/index.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 
-import { useRootData } from '../../store/DateInfo/dateInfoHook';
-import CalculateDate from '../../util/calculateDate';
-import DetailModal from './DetailModal';
+import { useRootData } from '../../../store/DateInfo/dateInfoHook';
+import CalculateDate from '../../../util/calculateDate';
+import DetailModal from '../DetailModal';
 import './calendar.scss';
 
 export default function Calendar() {

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -16,8 +16,8 @@
   .clicked-date {
     position: absolute;
     border-radius: $basic-border-radius;
-    width: 50em;
-    height: 35em;
+    width: 50%;
+    height: 70%;
     background-color: $light-grey;
     padding: 2em 0;
     margin-top: 5%;
@@ -40,6 +40,13 @@
     }
     .cal-transition {
       margin-top: 2em;
+      width: 100%;
+
+      .specific__transaction__unit {
+        width: 100%;
+        display: flex;
+        padding: 1em;
+      }
     }
   }
 }

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -1,0 +1,45 @@
+@use '../../../styles/values' as *;
+@use '../../../styles/mixins' as *;
+
+.detail-info-overlay {
+  position: absolute;
+  width: 100%;
+  height: 80%;
+  background-color: $modal-background;
+  display: flex;
+  justify-content: center;
+
+  &.hidden {
+    display: none;
+  }
+
+  .clicked-date {
+    position: absolute;
+    border-radius: $basic-border-radius;
+    width: 50em;
+    height: 35em;
+    background-color: $light-grey;
+    padding: 2em 0;
+    margin-top: 5%;
+    overflow-y: scroll;
+    scroll-behavior: smooth;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    .cal-date-info {
+      display: flex;
+      gap: 1em;
+      font-size: 1.5em;
+
+      .cal-year,
+      .cal-month,
+      .cal-date {
+        display: inline-block;
+      }
+    }
+    .cal-transition {
+      margin-top: 2em;
+    }
+  }
+}

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -18,7 +18,7 @@
     border-radius: $basic-border-radius;
     width: 50%;
     height: 70%;
-    background-color: $light-grey;
+    background-color: transparent;
     padding: 2em 0;
     margin-top: 5%;
     overflow-y: scroll;
@@ -26,26 +26,46 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    border: 1px solid white;
+    color: white;
 
     .cal-date-info {
       display: flex;
       gap: 1em;
-      font-size: 1.5em;
-
-      .cal-year,
-      .cal-month,
-      .cal-date {
-        display: inline-block;
-      }
+      font-size: 1.2em;
     }
     .cal-transition {
       margin-top: 2em;
       width: 100%;
+      padding: 1em;
+      display: flex;
+      flex-direction: column;
+      gap: 1em;
 
       .specific__transaction__unit {
         width: 100%;
         display: flex;
         padding: 1em;
+        border: 1px solid white;
+        border-radius: $basic-border-radius;
+        background-color: #333;
+        color: white;
+        position: relative;
+
+        .specific__content {
+          position: absolute;
+          left: 30%;
+        }
+
+        .specific__payment {
+          position: absolute;
+          right: 30%;
+        }
+
+        .specific__cost {
+          position: absolute;
+          right: 5%;
+        }
       }
     }
   }

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -75,10 +75,10 @@
           right: 5%;
 
           &.income {
-            color: #54aafc;
+            color: $income-color;
           }
           &.spending {
-            color: #ee4337;
+            color: $spending-color;
           }
         }
       }

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -2,12 +2,13 @@
 @use '../../../styles/mixins' as *;
 
 .detail-info-overlay {
-  position: absolute;
+  position: fixed;
   width: 100%;
-  height: 80%;
+  height: 120%;
   background-color: $modal-background;
   display: flex;
   justify-content: center;
+  z-index: 3;
 
   &.hidden {
     display: none;
@@ -17,10 +18,10 @@
     position: absolute;
     border-radius: $basic-border-radius;
     width: 45%;
-    height: 75%;
+    height: 55%;
     background-color: transparent;
     padding: 2em 0;
-    margin-top: 5%;
+    margin-top: 10%;
     overflow-y: scroll;
     scroll-behavior: smooth;
     display: flex;
@@ -40,6 +41,8 @@
       display: flex;
       gap: 1em;
       font-size: 1.2em;
+      color: white;
+      text-shadow: $selectedTextShadow;
     }
     .cal-transition {
       margin-top: 2em;
@@ -59,7 +62,14 @@
         background-color: #333;
         color: #979797;
         position: relative;
+        animation: specificDataShow 1s;
 
+        @keyframes specificDataShow {
+          from {
+            opacity: 0;
+            transform: translateX(-100px);
+          }
+        }
         .specific__content {
           position: absolute;
           left: 30%;

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -16,8 +16,8 @@
   .clicked-date {
     position: absolute;
     border-radius: $basic-border-radius;
-    width: 50%;
-    height: 70%;
+    width: 45%;
+    height: 75%;
     background-color: transparent;
     padding: 2em 0;
     margin-top: 5%;
@@ -26,8 +26,15 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    border: 1px solid white;
-    color: white;
+    border: 1px solid #979797;
+    color: #979797;
+
+    animation: detailFormShow 1s;
+    @keyframes detailFormShow {
+      from {
+        transform: translateY(500px);
+      }
+    }
 
     .cal-date-info {
       display: flex;
@@ -37,6 +44,7 @@
     .cal-transition {
       margin-top: 2em;
       width: 100%;
+      height: 100%;
       padding: 1em;
       display: flex;
       flex-direction: column;
@@ -46,10 +54,10 @@
         width: 100%;
         display: flex;
         padding: 1em;
-        border: 1px solid white;
+        border: 1px solid #979797;
         border-radius: $basic-border-radius;
         background-color: #333;
-        color: white;
+        color: #979797;
         position: relative;
 
         .specific__content {
@@ -65,7 +73,23 @@
         .specific__cost {
           position: absolute;
           right: 5%;
+
+          &.income {
+            color: #54aafc;
+          }
+          &.spending {
+            color: #ee4337;
+          }
         }
+      }
+
+      .no__specific__data {
+        text-align: center;
+        font-size: 3em;
+        border-radius: $basic-border-radius;
+        color: white;
+
+        text-shadow: $selectedTextShadow;
       }
     }
   }

--- a/FE/src/components/Calendar/DetailModal/index.tsx
+++ b/FE/src/components/Calendar/DetailModal/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useCallback } from 'react';
 
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import { useTransactionData } from '../../../store/TransactionData/transactionInfoHook';
+import CommaMaker from '../../../util/commaForMoney';
 import './detailModal.scss';
 
 export default function DetailModal({ setDetailModal }) {
@@ -58,11 +59,11 @@ export default function DetailModal({ setDetailModal }) {
                   </span>
                   {item.type === '지출' ? (
                     <span className="specific__cost spending">
-                      -{item.cost}원
+                      -{CommaMaker(item.cost)}원
                     </span>
                   ) : (
                     <span className="specific__cost income">
-                      +{item.cost}원
+                      +{CommaMaker(item.cost)}원
                     </span>
                   )}
                 </div>

--- a/FE/src/components/Calendar/DetailModal/index.tsx
+++ b/FE/src/components/Calendar/DetailModal/index.tsx
@@ -45,18 +45,22 @@ export default function DetailModal({ setDetailModal }) {
           <span className="cal-date" ref={calDateRef} />
         </div>
         <div className="cal-transition">
-          {transactions.map(item => {
-            return (
-              <div className="specific__transaction__unit" key={item._id}>
-                <span className="specific__cost">{item.type}</span>
-                <span className="specific__cost">{item.category.name}</span>
-                <span className="specific__cost">
-                  {item.payment.description}
-                </span>
-                <span className="specific__cost">{item.cost}</span>
-              </div>
-            );
-          })}
+          {transactions.length !== 0 ? (
+            transactions.map(item => {
+              return (
+                <div className="specific__transaction__unit" key={item._id}>
+                  <span className="specific__cost">{item.type}</span>
+                  <span className="specific__cost">{item.category.name}</span>
+                  <span className="specific__cost">
+                    {item.payment.description}
+                  </span>
+                  <span className="specific__cost">{item.cost}</span>
+                </div>
+              );
+            })
+          ) : (
+            <div>No Transactions</div>
+          )}
         </div>
       </div>
     </div>

--- a/FE/src/components/Calendar/DetailModal/index.tsx
+++ b/FE/src/components/Calendar/DetailModal/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
+import { useTransactionData } from '../../../store/TransactionData/transactionInfoHook';
 import './detailModal.scss';
 
 export default function DetailModal({ setDetailModal }) {
@@ -9,6 +10,15 @@ export default function DetailModal({ setDetailModal }) {
   const calYearRef = useRef();
 
   const DateInfo = useRootData(store => store.nowCalendarInfo);
+  const SpecificTransactions = useTransactionData(
+    store => store.getSpecificTransactions,
+  );
+
+  const transactions = SpecificTransactions(
+    DateInfo.year,
+    DateInfo.month + 1,
+    DateInfo.day,
+  );
 
   const loadDate = useCallback(() => {
     calYearRef.current.textContent = `${DateInfo.year}년`;
@@ -34,7 +44,20 @@ export default function DetailModal({ setDetailModal }) {
           <span className="cal-month" ref={calMonthRef} />
           <span className="cal-date" ref={calDateRef} />
         </div>
-        <div className="cal-transition">내역들</div>
+        <div className="cal-transition">
+          {transactions.map(item => {
+            return (
+              <div className="specific__transaction__unit" key={item._id}>
+                <span className="specific__cost">{item.type}</span>
+                <span className="specific__cost">{item.category.name}</span>
+                <span className="specific__cost">
+                  {item.payment.description}
+                </span>
+                <span className="specific__cost">{item.cost}</span>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/FE/src/components/Calendar/DetailModal/index.tsx
+++ b/FE/src/components/Calendar/DetailModal/index.tsx
@@ -47,9 +47,15 @@ export default function DetailModal({ setDetailModal }) {
         </div>
         <div className="cal-transition">
           {transactions.length !== 0 ? (
-            transactions.map(item => {
+            transactions.map((item, i) => {
               return (
-                <div className="specific__transaction__unit" key={item._id}>
+                <div
+                  className="specific__transaction__unit"
+                  key={item._id}
+                  style={{
+                    animationDelay: `${i * 0.05}s`,
+                  }}
+                >
                   <span className="specific__category">
                     {item.category.name}
                   </span>

--- a/FE/src/components/Calendar/DetailModal/index.tsx
+++ b/FE/src/components/Calendar/DetailModal/index.tsx
@@ -1,0 +1,41 @@
+import React, { useEffect, useRef, useCallback } from 'react';
+
+import { useRootData } from '../../../store/DateInfo/dateInfoHook';
+import './detailModal.scss';
+
+export default function DetailModal({ setDetailModal }) {
+  const calDateRef = useRef();
+  const calMonthRef = useRef();
+  const calYearRef = useRef();
+
+  const DateInfo = useRootData(store => store.nowCalendarInfo);
+
+  const loadDate = useCallback(() => {
+    calYearRef.current.textContent = `${DateInfo.year}년`;
+    calMonthRef.current.textContent = `${DateInfo.month + 1}월`;
+    calDateRef.current.textContent = `${DateInfo.day}일`;
+  }, [DateInfo]);
+
+  const onClickDetailOverlay = event => {
+    if (event.target.classList.contains('detail-info-overlay')) {
+      setDetailModal(false);
+    }
+  };
+
+  useEffect(() => {
+    loadDate();
+  }, []);
+
+  return (
+    <div className="detail-info-overlay" onClick={onClickDetailOverlay}>
+      <div className="clicked-date">
+        <div className="cal-date-info">
+          <span className="cal-year" ref={calYearRef} />
+          <span className="cal-month" ref={calMonthRef} />
+          <span className="cal-date" ref={calDateRef} />
+        </div>
+        <div className="cal-transition">내역들</div>
+      </div>
+    </div>
+  );
+}

--- a/FE/src/components/Calendar/DetailModal/index.tsx
+++ b/FE/src/components/Calendar/DetailModal/index.tsx
@@ -56,14 +56,20 @@ export default function DetailModal({ setDetailModal }) {
                   <span className="specific__payment">
                     {item.payment.description}
                   </span>
-                  <span className="specific__cost">
-                    {item.type === '지출' ? `-${item.cost}` : `+${item.cost}`}
-                  </span>
+                  {item.type === '지출' ? (
+                    <span className="specific__cost spending">
+                      -{item.cost}원
+                    </span>
+                  ) : (
+                    <span className="specific__cost income">
+                      +{item.cost}원
+                    </span>
+                  )}
                 </div>
               );
             })
           ) : (
-            <div>No Transactions</div>
+            <div className="no__specific__data">No Transactions</div>
           )}
         </div>
       </div>

--- a/FE/src/components/Calendar/DetailModal/index.tsx
+++ b/FE/src/components/Calendar/DetailModal/index.tsx
@@ -49,12 +49,16 @@ export default function DetailModal({ setDetailModal }) {
             transactions.map(item => {
               return (
                 <div className="specific__transaction__unit" key={item._id}>
-                  <span className="specific__cost">{item.type}</span>
-                  <span className="specific__cost">{item.category.name}</span>
-                  <span className="specific__cost">
+                  <span className="specific__category">
+                    {item.category.name}
+                  </span>
+                  <span className="specific__content">{item.content}</span>
+                  <span className="specific__payment">
                     {item.payment.description}
                   </span>
-                  <span className="specific__cost">{item.cost}</span>
+                  <span className="specific__cost">
+                    {item.type === '지출' ? `-${item.cost}` : `+${item.cost}`}
+                  </span>
                 </div>
               );
             })

--- a/FE/src/components/Calendar/TotalContent/index.tsx
+++ b/FE/src/components/Calendar/TotalContent/index.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
+
+import { useRootData } from '../../../store/DateInfo/dateInfoHook';
+import { useTransactionData } from '../../../store/TransactionData/transactionInfoHook';
 import './totalContent.scss';
 
 export default function TotalContent(props) {
+  const DateInfo = useRootData(store => store.nowCalendarInfo);
+  const incomeTotal = useTransactionData(store =>
+    store.getIncomeTotal(DateInfo.year, DateInfo.month + 1),
+  );
+  const spendingTotal = useTransactionData(store =>
+    store.getSpendingTotal(DateInfo.year, DateInfo.month + 1),
+  );
+
   return (
     <div className="calendar__total__price">
-      <div className="calendar__income__total">수입합</div>
-      <div className="calendar__spending__total">지출합</div>
+      <div className="calendar__income__total">+{incomeTotal}원</div>
+      <div className="calendar__spending__total">-{spendingTotal}원</div>
     </div>
   );
 }

--- a/FE/src/components/Calendar/TotalContent/index.tsx
+++ b/FE/src/components/Calendar/TotalContent/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import './totalContent.scss';
+
+export default function TotalContent(props) {
+  return (
+    <div className="calendar__total__price">
+      <div className="calendar__income__total">수입합</div>
+      <div className="calendar__spending__total">지출합</div>
+    </div>
+  );
+}

--- a/FE/src/components/Calendar/TotalContent/index.tsx
+++ b/FE/src/components/Calendar/TotalContent/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import { useTransactionData } from '../../../store/TransactionData/transactionInfoHook';
+import CommaMaker from '../../../util/commaForMoney';
 import './totalContent.scss';
 
 export default function TotalContent(props) {
@@ -15,8 +16,12 @@ export default function TotalContent(props) {
 
   return (
     <div className="calendar__total__price">
-      <div className="calendar__income__total">+{incomeTotal}원</div>
-      <div className="calendar__spending__total">-{spendingTotal}원</div>
+      <div className="calendar__income__total">
+        +{CommaMaker(incomeTotal)}원
+      </div>
+      <div className="calendar__spending__total">
+        -{CommaMaker(spendingTotal)}원
+      </div>
     </div>
   );
 }

--- a/FE/src/components/Calendar/TotalContent/totalContent.scss
+++ b/FE/src/components/Calendar/TotalContent/totalContent.scss
@@ -1,21 +1,29 @@
+@mixin calendar-total($type) {
+  width: 25%;
+  text-align: center;
+  border-radius: 50px;
+  padding: 1em 5em;
+  @if $type== income {
+    border: 1.5px solid #54aafc;
+    color: #54aafc;
+  } @else {
+    border: 1.5px solid #ee4337;
+    color: #ee4337;
+  }
+}
+
 .calendar__total__price {
   position: absolute;
+  width: 100%;
   top: 12em;
-  left: 50%;
-  transform: translateX(-50%);
   display: flex;
+  justify-content: center;
   gap: 5em;
 
   .calendar__income__total {
-    border: 1.5px solid #54aafc;
-    border-radius: 50px;
-    color: #54aafc;
-    padding: 1em 5em;
+    @include calendar-total(income);
   }
   .calendar__spending__total {
-    border: 1.5px solid #ee4337;
-    border-radius: 50px;
-    color: #ee4337;
-    padding: 1em 5em;
+    @include calendar-total(spending);
   }
 }

--- a/FE/src/components/Calendar/TotalContent/totalContent.scss
+++ b/FE/src/components/Calendar/TotalContent/totalContent.scss
@@ -15,7 +15,7 @@
 .calendar__total__price {
   position: absolute;
   width: 100%;
-  top: 12em;
+  top: 25%;
   display: flex;
   justify-content: center;
   gap: 5em;

--- a/FE/src/components/Calendar/TotalContent/totalContent.scss
+++ b/FE/src/components/Calendar/TotalContent/totalContent.scss
@@ -1,0 +1,21 @@
+.calendar__total__price {
+  position: absolute;
+  top: 12em;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 5em;
+
+  .calendar__income__total {
+    border: 1.5px solid #54aafc;
+    border-radius: 50px;
+    color: #54aafc;
+    padding: 1em 5em;
+  }
+  .calendar__spending__total {
+    border: 1.5px solid #ee4337;
+    border-radius: 50px;
+    color: #ee4337;
+    padding: 1em 5em;
+  }
+}

--- a/FE/src/components/Calendar/TotalContent/totalContent.scss
+++ b/FE/src/components/Calendar/TotalContent/totalContent.scss
@@ -1,14 +1,16 @@
+@use '../../../styles/values.scss' as *;
+
 @mixin calendar-total($type) {
   width: 22%;
   text-align: center;
   border-radius: 50px;
   padding: 1em 5em;
   @if $type== income {
-    border: 1.5px solid #54aafc;
-    color: #54aafc;
+    border: 1.5px solid $income-color;
+    color: $income-color;
   } @else {
-    border: 1.5px solid #ee4337;
-    color: #ee4337;
+    border: 1.5px solid $spending-color;
+    color: $spending-color;
   }
 }
 

--- a/FE/src/components/Calendar/TotalContent/totalContent.scss
+++ b/FE/src/components/Calendar/TotalContent/totalContent.scss
@@ -1,5 +1,5 @@
 @mixin calendar-total($type) {
-  width: 25%;
+  width: 22%;
   text-align: center;
   border-radius: 50px;
   padding: 1em 5em;

--- a/FE/src/components/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/calendar.scss
@@ -3,6 +3,7 @@
 
 .calendar-container {
   width: 100%;
+  height: 80%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -78,46 +79,6 @@
           width: 100%;
           height: 4px;
           background: #ffc107;
-        }
-      }
-    }
-
-    .detail-info-overlay {
-      position: absolute;
-      width: 100%;
-      height: 80%;
-      background-color: $modal-background;
-      display: flex;
-      justify-content: center;
-
-      &.hidden {
-        display: none;
-      }
-
-      .clicked-date {
-        position: absolute;
-        border-radius: $basic-border-radius;
-        width: 50em;
-        height: 35em;
-        background-color: $light-grey;
-        padding: 2em 0;
-        margin-top: 5%;
-        overflow-y: scroll;
-        scroll-behavior: smooth;
-
-        .cal-date-info {
-          display: flex;
-          gap: 1em;
-          font-size: 1.5em;
-          justify-content: center;
-          .cal-year,
-          .cal-month,
-          .cal-date {
-            display: inline-block;
-          }
-        }
-        .cal-transition {
-          margin-top: 2em;
         }
       }
     }

--- a/FE/src/components/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/calendar.scss
@@ -9,8 +9,7 @@
 
   .my-calendar {
     width: 100%;
-    margin: 30px;
-    padding: 20px 20px 10px;
+
     text-align: center;
     font-weight: 800;
     display: flex;
@@ -83,29 +82,42 @@
       }
     }
 
-    .detail__overlay {
+    .detail-info-overlay {
+      position: absolute;
       width: 100%;
-      height: 100%;
-      position: fixed;
+      height: 80%;
       background-color: $modal-background;
+      display: flex;
+      justify-content: center;
+
       &.hidden {
         display: none;
       }
+
       .clicked-date {
         position: absolute;
-        border-radius: 25px;
-        margin-top: 36px;
-        float: right;
-        width: 20%;
-        padding: 46px 0 26px;
+        border-radius: $basic-border-radius;
+        width: 50em;
+        height: 35em;
         background-color: $light-grey;
+        padding: 2em 0;
+        margin-top: 5%;
+        overflow-y: scroll;
+        scroll-behavior: smooth;
 
-        .cal-day {
-          font-size: 2em;
+        .cal-date-info {
+          display: flex;
+          gap: 1em;
+          font-size: 1.5em;
+          justify-content: center;
+          .cal-year,
+          .cal-month,
+          .cal-date {
+            display: inline-block;
+          }
         }
-
-        .cal-date {
-          font-size: 3em;
+        .cal-transition {
+          margin-top: 2em;
         }
       }
     }

--- a/FE/src/components/Calendar/calendar.scss
+++ b/FE/src/components/Calendar/calendar.scss
@@ -23,6 +23,7 @@
       .cal-table {
         margin-top: 5em;
         width: 100%;
+
         th {
           width: 14.2857%;
           padding-bottom: 5px;

--- a/FE/src/components/Calendar/index.tsx
+++ b/FE/src/components/Calendar/index.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useContext, useCallback } from 'react';
+import React, { useRef, useEffect, useState, useCallback } from 'react';
 
 import { useRootData } from '../../store/DateInfo/dateInfoHook';
 import CalculateDate from '../../util/calculateDate';
@@ -6,15 +6,18 @@ import './calendar.scss';
 
 const Calendar = props => {
   const calDateRef = useRef();
-  const calDayRef = useRef();
+  const calMonthRef = useRef();
+  const calYearRef = useRef();
   const calBodyRef = useRef();
-  const detailRef = useRef();
+
+  const [detailModal, setDetailModal] = useState(false);
 
   const DateInfo = useRootData(store => store.nowCalendarInfo);
 
-  const loadDate = (date, dayIn) => {
+  const loadDate = (year, month, date) => {
+    calYearRef.current.textContent = `${year}년`;
+    calMonthRef.current.textContent = `${month}월`;
     calDateRef.current.textContent = `${date}일`;
-    calDayRef.current.textContent = CalculateDate.dayList[dayIn];
   };
 
   const makeCalendar = (year, month) => {
@@ -77,20 +80,26 @@ const Calendar = props => {
 
   const onClickCalBody = useCallback(event => {
     if (event.target.classList.contains('day')) {
-      if (CalculateDate.activeDTag) {
-        CalculateDate.activeDTag.classList.remove('day-active');
-      }
+      const { year } = DateInfo;
+      const { month } = DateInfo;
       const day = Number(event.target.textContent);
-      loadDate(day, event.target.cellIndex);
-      event.target.classList.add('day-active');
+
+      loadDate(year, month + 1, day); // 요일검증을 위한값
       CalculateDate.activeDTag = event.target;
       CalculateDate.activeDate.setDate(day);
+      setDetailModal(true);
     }
   }, []);
 
+  const onClickDetailOverlay = event => {
+    if (event.target.classList.contains('detail-info-overlay')) {
+      setDetailModal(false);
+    }
+  };
+
   useEffect(() => {
     makeCalendar(DateInfo.year, DateInfo.month);
-    loadDate(CalculateDate.today.getDate(), CalculateDate.today.getDay());
+    loadDate(DateInfo.year, DateInfo.month + 1, CalculateDate.today.getDate());
   }, [DateInfo]);
 
   return (
@@ -116,10 +125,18 @@ const Calendar = props => {
             />
           </table>
         </div>
-        <div ref={detailRef} className="detail__overlay hidden">
+        <div
+          className={
+            detailModal ? 'detail-info-overlay' : 'detail-info-overlay hidden'
+          }
+          onClick={onClickDetailOverlay}
+        >
           <div className="clicked-date">
-            <div className="cal-day" ref={calDayRef} />
-            <div className="cal-date" ref={calDateRef} />
+            <div className="cal-date-info">
+              <span className="cal-year" ref={calYearRef} />
+              <span className="cal-month" ref={calMonthRef} />
+              <span className="cal-date" ref={calDateRef} />
+            </div>
             <div className="cal-transition">내역들</div>
           </div>
         </div>

--- a/FE/src/components/Calendar/index.tsx
+++ b/FE/src/components/Calendar/index.tsx
@@ -8,7 +8,7 @@ import './calendar.scss';
 export default function Calendar() {
   const calBodyRef = useRef();
 
-  const [detailModal, setDetailModal] = useState(true);
+  const [detailModal, setDetailModal] = useState(false);
 
   const DateInfo = useRootData(store => store.nowCalendarInfo);
   const setDateInfo = useRootData(store => store.setCalendarInfo);

--- a/FE/src/components/Calendar/index.tsx
+++ b/FE/src/components/Calendar/index.tsx
@@ -8,7 +8,7 @@ import './calendar.scss';
 export default function Calendar() {
   const calBodyRef = useRef();
 
-  const [detailModal, setDetailModal] = useState(false);
+  const [detailModal, setDetailModal] = useState(true);
 
   const DateInfo = useRootData(store => store.nowCalendarInfo);
   const setDateInfo = useRootData(store => store.setCalendarInfo);

--- a/FE/src/components/CategoryChart/PieChart/index.tsx
+++ b/FE/src/components/CategoryChart/PieChart/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 
+import { v4 } from 'uuid';
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import ChartColorCollections from '../../../util/chartColorCollection';
 import './pieChart.scss';
@@ -29,7 +30,8 @@ export default function PieChart({ chartInfo, refArr }) {
       {chartInfo.map((el, i) => {
         return (
           <svg
-            key={DateInfo.year + DateInfo.month + el.category}
+            key={v4()}
+            // key={DateInfo.year + DateInfo.month + el.category}
             className="s_donut"
             width="300"
             height="300"

--- a/FE/src/components/CategoryChart/PieChart/index.tsx
+++ b/FE/src/components/CategoryChart/PieChart/index.tsx
@@ -1,9 +1,12 @@
 import React, { useEffect } from 'react';
-import { v4 } from 'uuid';
+
+import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import ChartColorCollections from '../../../util/chartColorCollection';
 import './pieChart.scss';
 
 export default function PieChart({ chartInfo, refArr }) {
+  const DateInfo = useRootData(store => store.nowCalendarInfo);
+
   const drawAnimation = () => {
     if (chartInfo.length !== 0) {
       refArr.forEach((_, i) => {
@@ -25,7 +28,12 @@ export default function PieChart({ chartInfo, refArr }) {
     <>
       {chartInfo.map((el, i) => {
         return (
-          <svg key={v4()} className="s_donut" width="300" height="300">
+          <svg
+            key={DateInfo.year + DateInfo.month + el.category}
+            className="s_donut"
+            width="300"
+            height="300"
+          >
             <circle
               ref={refArr[i]}
               className="donut"

--- a/FE/src/components/CategoryChart/PieChart/index.tsx
+++ b/FE/src/components/CategoryChart/PieChart/index.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 
-import { v4 } from 'uuid';
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import ChartColorCollections from '../../../util/chartColorCollection';
 import './pieChart.scss';
@@ -30,8 +29,7 @@ export default function PieChart({ chartInfo, refArr }) {
       {chartInfo.map((el, i) => {
         return (
           <svg
-            key={v4()}
-            // key={DateInfo.year + DateInfo.month + el.category}
+            key={DateInfo.year + DateInfo.month + el.category}
             className="s_donut"
             width="300"
             height="300"

--- a/FE/src/components/CategoryChart/TableChart/index.tsx
+++ b/FE/src/components/CategoryChart/TableChart/index.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
+import { v4 } from 'uuid';
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import ChartColorCollections from '../../../util/chartColorCollection';
 import './tableChart.scss';
 
 export default function TableChart({ chartInfo }) {
   const DateInfo = useRootData(store => store.nowCalendarInfo);
+
   return (
     <div className="pie__table">
       {chartInfo &&
         chartInfo.map((el, i) => (
           <div
             className="stat__unit"
-            key={DateInfo.year + DateInfo.month + el.category}
+            key={v4()}
+            // key={DateInfo.year + DateInfo.month + el.category}
           >
             <span className="stat__category">{el.category}</span>
-            <span className="stat__percent">{Math.floor(el.percent)}%</span>
+            <span className="stat__percent"> {Math.floor(el.percent)}%</span>
             <span className="stat__background">
               <span
                 className="stat__color"
@@ -26,7 +29,7 @@ export default function TableChart({ chartInfo }) {
                 }}
               />
             </span>
-            <span className="stat__price">{el.cost}원</span>
+            <span className="stat__price"> {el.cost}원</span>
           </div>
         ))}
     </div>

--- a/FE/src/components/CategoryChart/TableChart/index.tsx
+++ b/FE/src/components/CategoryChart/TableChart/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { v4 } from 'uuid';
+
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import ChartColorCollections from '../../../util/chartColorCollection';
 import './tableChart.scss';
@@ -13,8 +13,7 @@ export default function TableChart({ chartInfo }) {
         chartInfo.map((el, i) => (
           <div
             className="stat__unit"
-            key={v4()}
-            // key={DateInfo.year + DateInfo.month + el.category}
+            key={DateInfo.year + DateInfo.month + el.category}
           >
             <span className="stat__category">{el.category}</span>
             <span className="stat__percent"> {Math.floor(el.percent)}%</span>

--- a/FE/src/components/CategoryChart/TableChart/index.tsx
+++ b/FE/src/components/CategoryChart/TableChart/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useRootData } from '../../../store/DateInfo/dateInfoHook';
+import CommaMaker from '../../../util/commaForMoney';
 import ChartColorCollections from '../../../util/chartColorCollection';
 import './tableChart.scss';
 
@@ -28,7 +29,7 @@ export default function TableChart({ chartInfo }) {
                 }}
               />
             </span>
-            <span className="stat__price"> {el.cost}원</span>
+            <span className="stat__price"> {CommaMaker(el.cost)}원</span>
           </div>
         ))}
     </div>

--- a/FE/src/components/CategoryChart/TableChart/index.tsx
+++ b/FE/src/components/CategoryChart/TableChart/index.tsx
@@ -1,14 +1,18 @@
 import React from 'react';
-import { v4 } from 'uuid';
+import { useRootData } from '../../../store/DateInfo/dateInfoHook';
 import ChartColorCollections from '../../../util/chartColorCollection';
 import './tableChart.scss';
 
 export default function TableChart({ chartInfo }) {
+  const DateInfo = useRootData(store => store.nowCalendarInfo);
   return (
     <div className="pie__table">
       {chartInfo &&
         chartInfo.map((el, i) => (
-          <div className="stat__unit" key={v4()}>
+          <div
+            className="stat__unit"
+            key={DateInfo.year + DateInfo.month + el.category}
+          >
             <span className="stat__category">{el.category}</span>
             <span className="stat__percent">{Math.floor(el.percent)}%</span>
             <span className="stat__background">

--- a/FE/src/components/Common/MenuBar/menubar.scss
+++ b/FE/src/components/Common/MenuBar/menubar.scss
@@ -4,6 +4,7 @@
 .menubar__header {
   background-color: $light-black;
   width: 100%;
+  height: 20%;
   padding: 1.5em 0;
   z-index: 2;
   .menubar__buttons {

--- a/FE/src/components/PaymentMethod/AddTemplate/addForm.scss
+++ b/FE/src/components/PaymentMethod/AddTemplate/addForm.scss
@@ -20,6 +20,18 @@
   flex-direction: column;
   z-index: 3;
 
+  &.selected {
+    animation: selectedMethodShow 1.5s;
+  }
+
+  @keyframes selectedMethodShow {
+    from {
+      opacity: 0;
+
+      transform: translate(-50%, 60%);
+    }
+  }
+
   .addform__method__name {
     width: 70%;
     margin: auto;

--- a/FE/src/components/PaymentMethod/AddTemplate/index.tsx
+++ b/FE/src/components/PaymentMethod/AddTemplate/index.tsx
@@ -44,7 +44,11 @@ export default function AddTemplate({
 
   return (
     <div
-      className="addform__wrapper"
+      className={
+        addTemplateData.name.length === 0
+          ? 'addform__wrapper'
+          : 'addform__wrapper selected'
+      }
       style={{ background: `${addTemplateData.color}` }}
     >
       {addTemplateData.name || '아래에서 카드를 선택해주세요.'}

--- a/FE/src/components/PaymentMethod/Modal/index.tsx
+++ b/FE/src/components/PaymentMethod/Modal/index.tsx
@@ -8,7 +8,10 @@ import { useRootData } from '../../../store/PaymentMethod/paymentMethodHook';
 
 import './modal.scss';
 
-export default function Modal({ setModal, defaultMethod }): React.ReactElement {
+export default function PaymentModal({
+  setModal,
+  defaultMethod,
+}): React.ReactElement {
   const [addFormModal, setAddFormModal] = useState(false);
   const paymentMethods = useRootData(store => store.paymentMethod);
 

--- a/FE/src/components/TransactionByDate/index.tsx
+++ b/FE/src/components/TransactionByDate/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function TransactionByDate() {
+  return (
+    <div ref={detailRef} className="detail__overlay hidden">
+      <div className="clicked-date">
+        <div className="cal-day" ref={calDayRef} />
+        <div className="cal-date" ref={calDateRef} />
+        <div className="cal-transition">내역들</div>
+      </div>
+    </div>
+  );
+}

--- a/FE/src/pages/Calendar/calendar.scss
+++ b/FE/src/pages/Calendar/calendar.scss
@@ -5,4 +5,26 @@
   display: flex;
   flex-direction: column;
   scroll-behavior: smooth;
+
+  .calendar__total__price {
+    position: absolute;
+    top: 12em;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 5em;
+
+    .calendar__income__total {
+      border: 1.5px solid #54aafc;
+      border-radius: 50px;
+      color: #54aafc;
+      padding: 1em 5em;
+    }
+    .calendar__spending__total {
+      border: 1.5px solid #ee4337;
+      border-radius: 50px;
+      color: #ee4337;
+      padding: 1em 5em;
+    }
+  }
 }

--- a/FE/src/pages/Calendar/calendar.scss
+++ b/FE/src/pages/Calendar/calendar.scss
@@ -5,26 +5,4 @@
   display: flex;
   flex-direction: column;
   scroll-behavior: smooth;
-
-  .calendar__total__price {
-    position: absolute;
-    top: 12em;
-    left: 50%;
-    transform: translateX(-50%);
-    display: flex;
-    gap: 5em;
-
-    .calendar__income__total {
-      border: 1.5px solid #54aafc;
-      border-radius: 50px;
-      color: #54aafc;
-      padding: 1em 5em;
-    }
-    .calendar__spending__total {
-      border: 1.5px solid #ee4337;
-      border-radius: 50px;
-      color: #ee4337;
-      padding: 1em 5em;
-    }
-  }
 }

--- a/FE/src/pages/Calendar/index.tsx
+++ b/FE/src/pages/Calendar/index.tsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 
-import Modal from '../../components/PaymentMethod/Modal';
+import PaymentModal from '../../components/PaymentMethod/Modal';
 import MenuBar from '../../components/Common/MenuBar';
-import Calendar from '../../components/Calendar';
+import TotalContent from '../../components/Calendar/TotalContent';
+import Calendar from '../../components/Calendar/Calendar';
 import './calendar.scss';
 import useDefaultPayment from '../../service/useDefaultPayment';
 import useLoginCheck from '../../service/useLoginCheck';
@@ -15,9 +16,13 @@ export default function CalendarPage() {
   return (
     <div className="calendar__wrapper">
       <MenuBar setModal={setPaymentMethodModal} pageType="calendar" />
+      <TotalContent />
       <Calendar />
       {paymentMethodModal && (
-        <Modal setModal={setPaymentMethodModal} defaultMethod={defaultMethod} />
+        <PaymentModal
+          setModal={setPaymentMethodModal}
+          defaultMethod={defaultMethod}
+        />
       )}
     </div>
   );

--- a/FE/src/pages/Chart/index.tsx
+++ b/FE/src/pages/Chart/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import Modal from '../../components/PaymentMethod/Modal';
+import PaymentModal from '../../components/PaymentMethod/Modal';
 import MenuBar from '../../components/Common/MenuBar';
 import NavButton from '../../components/Chart/NavButton';
 import PieChart from '../../components/CategoryChart/PieChart';
@@ -49,7 +49,10 @@ const Chart = props => {
         </div>
       )}
       {paymentMethodModal && (
-        <Modal setModal={setPaymentMethodModal} defaultMethod={defaultMethod} />
+        <PaymentModal
+          setModal={setPaymentMethodModal}
+          defaultMethod={defaultMethod}
+        />
       )}
     </div>
   );

--- a/FE/src/service/useDefaultPayment.ts
+++ b/FE/src/service/useDefaultPayment.ts
@@ -4,9 +4,12 @@ import { useRootData } from '../store/PaymentMethod/paymentMethodHook';
 
 const useDefaultPayment = () => {
   const [defaultMethod, setDefaultMethod] = useState([]);
+
+  const initialDefaultMethods = useRootData(store => store.initialMethods);
   const storeData = useRootData(store => store.getDefaultMethods);
 
   const getDefaultMethod = async () => {
+    initialDefaultMethods();
     const datas = await storeData();
     setDefaultMethod(datas);
   };

--- a/FE/src/service/useDefaultPayment.ts
+++ b/FE/src/service/useDefaultPayment.ts
@@ -4,10 +4,10 @@ import { useRootData } from '../store/PaymentMethod/paymentMethodHook';
 
 const useDefaultPayment = () => {
   const [defaultMethod, setDefaultMethod] = useState([]);
-  const storeData = useRootData(store => store.defaultMethods);
+  const storeData = useRootData(store => store.getDefaultMethods);
 
   const getDefaultMethod = async () => {
-    const datas = await storeData;
+    const datas = await storeData();
     setDefaultMethod(datas);
   };
 

--- a/FE/src/store/DateInfo/dateInfoStore.ts
+++ b/FE/src/store/DateInfo/dateInfoStore.ts
@@ -6,11 +6,12 @@ export const createStore = () => {
       day: '',
     },
 
-    setCalendarInfo(year: number, month: number) {
+    setCalendarInfo(year: number, month: number, day: number) {
       this.nowCalendarInfo = {
         ...this.nowCalendarInfo,
         year,
         month,
+        day,
       };
     },
   };

--- a/FE/src/store/DateInfo/dateInfoStore.ts
+++ b/FE/src/store/DateInfo/dateInfoStore.ts
@@ -3,7 +3,7 @@ export const createStore = () => {
     nowCalendarInfo: {
       year: new Date().getFullYear(),
       month: new Date().getMonth(),
-      day: 0,
+      day: 1,
     },
 
     setCalendarInfo(year: number, month: number, day: number) {

--- a/FE/src/store/DateInfo/dateInfoStore.ts
+++ b/FE/src/store/DateInfo/dateInfoStore.ts
@@ -3,7 +3,7 @@ export const createStore = () => {
     nowCalendarInfo: {
       year: new Date().getFullYear(),
       month: new Date().getMonth(),
-      day: '',
+      day: 0,
     },
 
     setCalendarInfo(year: number, month: number, day: number) {

--- a/FE/src/store/PaymentMethod/paymentMethodStore.ts
+++ b/FE/src/store/PaymentMethod/paymentMethodStore.ts
@@ -2,7 +2,7 @@ import { getDefaultMethods } from '../../api/defaultPaymentMethod';
 
 export const createStore = () => {
   const store = {
-    defaultMethods: getDefaultMethods(),
+    defaultMethods: [],
     addTemplateData: { name: '', color: '' },
     paymentMethod: [
       {
@@ -18,6 +18,11 @@ export const createStore = () => {
       console.log('here');
       return datas;
     },
+
+    initialMethods() {
+      this.defaultMethods = getDefaultMethods();
+    },
+
     addPaymentMethod(data: { name: string; desc: string; color: string }) {
       this.paymentMethod = [data, ...this.paymentMethod];
     },

--- a/FE/src/store/PaymentMethod/paymentMethodStore.ts
+++ b/FE/src/store/PaymentMethod/paymentMethodStore.ts
@@ -12,6 +12,12 @@ export const createStore = () => {
       },
       { name: 'Kakao', desc: 'sub method', color: 'hsla(40, 100%, 50%, 0.93)' },
     ],
+
+    async getDefaultMethods() {
+      const datas = await this.defaultMethods;
+      console.log('here');
+      return datas;
+    },
     addPaymentMethod(data: { name: string; desc: string; color: string }) {
       this.paymentMethod = [data, ...this.paymentMethod];
     },

--- a/FE/src/store/TransactionData/transactionData.ts
+++ b/FE/src/store/TransactionData/transactionData.ts
@@ -32,7 +32,7 @@ export const createStore = () => {
       user: [1, 2, 3, 4],
       transaction: [
         {
-          _id: 'asdf',
+          _id: 'a',
           content: 'test',
           type: '지출',
           cost: 10000,
@@ -47,7 +47,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'b',
           content: 'test2',
           type: '지출',
           cost: 20000,
@@ -62,7 +62,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'c',
           content: 'test3',
           type: '지출',
           cost: 30000,
@@ -77,7 +77,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'd',
           content: 'test4',
           type: '지출',
           cost: 40000,
@@ -93,7 +93,7 @@ export const createStore = () => {
         },
 
         {
-          _id: 'asdf',
+          _id: 'e',
           content: 'test4',
           type: '지출',
           cost: 50000,
@@ -108,7 +108,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'f',
           content: 'test4',
           type: '지출',
           cost: 1000,
@@ -123,7 +123,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'g',
           content: 'test4',
           type: '지출',
           cost: 10000,
@@ -138,7 +138,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'h',
           content: '옷',
           type: '지출',
           cost: 1000000,
@@ -153,7 +153,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'i',
           content: '치킨',
           type: '지출',
           cost: 20000,
@@ -168,7 +168,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'j',
           content: '정기 교통비',
           type: '지출',
           cost: 30000,
@@ -183,7 +183,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'k',
           content: '영화보기',
           type: '지출',
           cost: 40000,
@@ -198,7 +198,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'l',
           content: '정기용돈',
           type: '수입',
           cost: 500000000,
@@ -213,7 +213,7 @@ export const createStore = () => {
           },
         },
         {
-          _id: 'asdf',
+          _id: 'm',
           content: '정기월급',
           type: '수입',
           cost: 400000000,
@@ -249,6 +249,21 @@ export const createStore = () => {
       this.accountBook.transaction.forEach(item => {
         if (
           item.type === '지출' &&
+          Number(item.date.split('-')[0]) === year &&
+          Number(item.date.split('-')[1]) === month
+        ) {
+          sum += item.cost;
+        }
+      });
+
+      return sum;
+    },
+    getIncomeTotal(year, month) {
+      let sum = 0;
+
+      this.accountBook.transaction.forEach(item => {
+        if (
+          item.type === '수입' &&
           Number(item.date.split('-')[0]) === year &&
           Number(item.date.split('-')[1]) === month
         ) {

--- a/FE/src/store/TransactionData/transactionData.ts
+++ b/FE/src/store/TransactionData/transactionData.ts
@@ -204,6 +204,16 @@ export const createStore = () => {
       return this.accountBook.transaction;
     },
 
+    getSpecificTransactions(year: number, month: number, day: number) {
+      const specificDatas = this.accountBook.transaction.filter(
+        item =>
+          year === Number(item.date.split('-')[0]) &&
+          month === Number(item.date.split('-')[1]) &&
+          day === Number(item.date.split('-')[2]),
+      );
+      return specificDatas;
+    },
+
     getSpendingTotal(year, month) {
       let sum = 0;
       this.accountBook.transaction.forEach(item => {

--- a/FE/src/store/TransactionData/transactionData.ts
+++ b/FE/src/store/TransactionData/transactionData.ts
@@ -139,12 +139,12 @@ export const createStore = () => {
         },
         {
           _id: 'asdf',
-          content: 'test',
+          content: '옷',
           type: '지출',
-          cost: 10000,
+          cost: 1000000,
           date: '2020-12-01',
           category: {
-            name: 'shopping',
+            name: '쇼핑',
             icon: 1,
           },
           payment: {
@@ -154,12 +154,12 @@ export const createStore = () => {
         },
         {
           _id: 'asdf',
-          content: 'test2',
+          content: '치킨',
           type: '지출',
           cost: 20000,
           date: '2020-12-01',
           category: {
-            name: 'food',
+            name: '식비',
             icon: 1,
           },
           payment: {
@@ -169,12 +169,12 @@ export const createStore = () => {
         },
         {
           _id: 'asdf',
-          content: 'test3',
+          content: '정기 교통비',
           type: '지출',
           cost: 30000,
           date: '2020-12-01',
           category: {
-            name: 'life',
+            name: '교통',
             icon: 1,
           },
           payment: {
@@ -184,12 +184,42 @@ export const createStore = () => {
         },
         {
           _id: 'asdf',
-          content: 'test4',
+          content: '영화보기',
           type: '지출',
           cost: 40000,
           date: '2020-12-01',
           category: {
-            name: 'etc',
+            name: '여가',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+        {
+          _id: 'asdf',
+          content: '정기용돈',
+          type: '수입',
+          cost: 500000000,
+          date: '2020-12-01',
+          category: {
+            name: '용돈',
+            icon: 1,
+          },
+          payment: {
+            card: 1,
+            description: 'naver',
+          },
+        },
+        {
+          _id: 'asdf',
+          content: '정기월급',
+          type: '수입',
+          cost: 400000000,
+          date: '2020-12-01',
+          category: {
+            name: '월급',
             icon: 1,
           },
           payment: {
@@ -235,6 +265,7 @@ export const createStore = () => {
 
       const datas = this.accountBook.transaction.filter(
         item =>
+          item.type === '지출' &&
           year === Number(item.date.split('-')[0]) &&
           month === Number(item.date.split('-')[1]),
       );

--- a/FE/src/store/TransactionData/transactionData.ts
+++ b/FE/src/store/TransactionData/transactionData.ts
@@ -234,6 +234,39 @@ export const createStore = () => {
       return this.accountBook.transaction;
     },
 
+    getTransactionsByYearMonth(year: number, month: number) {
+      const yearMonthDatas = this.accountBook.transaction.filter(
+        item =>
+          year === Number(item.date.split('-')[0]) &&
+          month === Number(item.date.split('-')[1]),
+      );
+
+      return yearMonthDatas;
+    },
+    getTransactionsForCalendar(year: number, month: number) {
+      const yearMonthDatas = this.accountBook.transaction.filter(
+        item =>
+          year === Number(item.date.split('-')[0]) &&
+          month === Number(item.date.split('-')[1]),
+      );
+
+      const priceSumData = {};
+
+      yearMonthDatas.forEach(item => {
+        const date = String(Number(item.date.split('-')[2]));
+        if (!priceSumData.hasOwnProperty(String(date))) {
+          item.type === '지출'
+            ? (priceSumData[`${date}`] = { spending: item.cost, income: 0 })
+            : (priceSumData[`${date}`] = { income: item.cost, spendiing: 0 });
+        } else {
+          item.type === '지출'
+            ? (priceSumData[`${date}`].spending += item.cost)
+            : (priceSumData[`${date}`].income += item.cost);
+        }
+      });
+
+      return priceSumData;
+    },
     getSpecificTransactions(year: number, month: number, day: number) {
       const specificDatas = this.accountBook.transaction.filter(
         item =>

--- a/FE/src/styles/values.scss
+++ b/FE/src/styles/values.scss
@@ -11,6 +11,8 @@ $black: black;
 $light-black: #222;
 $white: white;
 $light-grey: lightgrey;
+$income-color: #54aafc;
+$spending-color: #ee4337;
 // modal
 $modal-background: rgba(0, 0, 0, 0.9);
 $modal-button-background: rgba(0, 0, 0, 0.1);

--- a/FE/src/util/commaForMoney.ts
+++ b/FE/src/util/commaForMoney.ts
@@ -1,0 +1,3 @@
+export default function CommaMaker(money) {
+  return money.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #67 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] Calendar 탭에서 특정 날짜를 눌렀을 때 모달
- 특정 날짜 클릭시 해당 년,월,일에 해당하는 내역을 보여주는 모달이 보이도록 구현하였습니다.
- Calendar와 Modal이 합쳐져있었는데 컴포넌트를 분리하였습니다.
- 디자인 같은건 임시라서 이야기해보고 수정해야할 것 같습니다


<img width="1671" alt="스크린샷 2020-12-01 오후 10 09 42" src="https://user-images.githubusercontent.com/49441876/100745001-fdb51400-3421-11eb-89c6-24a3aedff48c.png">


- [x] Calendar 페이지에 지출합, 수입합 표기
- 전역으로 관리하는 데이터로부터 해당 년,월의  내역데이터를 가지고 계산하여 상단에 표기해 주었습니다.
- 전역으로 관리하는 데이터로부터 해당 년,월의  내역데이터를 가지고 일별 수입,지출 데이터를 만든다음 달력 일자에 표기하였습니다.
- 리액트스럽게 리팩토링하는걸 고려해봐야 할 것 같습니다.
- 디자인 같은건 임시라서 이야기해보고 수정해야할 것 같습니다

<img width="1677" alt="스크린샷 2020-12-01 오후 10 09 28" src="https://user-images.githubusercontent.com/49441876/100744997-fb52ba00-3421-11eb-8adc-f781da242299.png">

- [x] chart그릴 때 key값 변경
- 이 브랜치에서 할 작업은 아닌데 들어가버렸네요 ...
- 자세한 사항은 wiki에 svg정리한 부분에 추가해 두었습니다!
- UX를 고려해서 수정해 보았습니다.

- [x] CommaMaker함수 구현
- 돈 단위에 맞게 콤마를 찍어주는 함수입니다.
- 해당 함수에서 String값으로 변환하여 가공한 뒤 return해주므로 number형식 , string형식 아무렇게나 넣어주어도 됩니다.
=> 단, 숫자로만 이루어져 있어야 합니다 ! (예 : 100000원 ->X , 100000 -> O)
- 어디서든 사용할 수 있도록 util로 분리해 두었습니다.
- 정규식 설명
```javascript
export default function CommaMaker(money) {
  return money.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
}

1. 매개변수 money를 string화 시킨다.
2. replace를 통해 조건에 맞는 위치에 , 를 찍어줄 것이다.
3. \B는 단어 경계가 아닌 부분에 대응시켜 준다. 단어 경계란 abcd가 있을때 a의 앞과 d의 뒤의 위치를 의미한다.
4. (\d{3}) 는 숫자가 3번 연속되는 것에 대응 된다.
5. +(?!\d) 는 숫자가 3번 연속되는 것이 1회 이상 반복되는 부분과 대응된다. 
6. x(?=y)는 정규식에서 오직 y가 뒤따르는 x에만 대응 되는 것을 의미한다.
결론 : 숫자가3번 연속되는 것이 1회이상 반복되는 해당위치가 단어경계 부분이 아니라면 콤마로 replace 해주는 것이다.
```
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
