### PR TITLE
[refactor] #37 가계부 목록 페이지 상태관리를 mobX에서 useState로 변경

### DIFF
--- a/FE/src/api/accoun-book-list.ts
+++ b/FE/src/api/accoun-book-list.ts
@@ -1,7 +1,7 @@
 import { getFetch, postFetch } from '../service/fetch';
 
-export const getAccountBookList = async () => {
-  const backendPath = process.env.BACKEND;
+export default async function getAccountBookList() {
+  const backendPath = process.env.SERVER_URL;
   const data = await getFetch(`${backendPath}/api/accountbook`);
   return data.reverse();
-};
+}

--- a/FE/src/app.tsx
+++ b/FE/src/app.tsx
@@ -21,25 +21,21 @@ const App = () => {
   return (
     <DateInfoProvider>
       <TransactionInfoProvider>
-        <AccountBookProvider>
-          <PaymentProvider>
-            <Router>
-              <Switch>
-                <Route exact path="/" component={AccountBookListPage} />
-                <Route exact path="/login" component={LoginPage} />
-                <Route
-                  exact
-                  path="/auth/github"
-                  component={GithubLoginProcess}
-                />
-                <Route exact path="/auth/naver" component={NaverLoginProcess} />
-                <Route exact path="/calendar" component={CalendarPage} />
-                <Route exact path="/transaction" component={TransactionPage} />
-                <Route exact path="/chart" component={ChartPage} />
-              </Switch>
-            </Router>
-          </PaymentProvider>
-        </AccountBookProvider>
+        {/* <AccountBookProvider> */}
+        <PaymentProvider>
+          <Router>
+            <Switch>
+              <Route exact path="/" component={AccountBookListPage} />
+              <Route exact path="/login" component={LoginPage} />
+              <Route exact path="/auth/github" component={GithubLoginProcess} />
+              <Route exact path="/auth/naver" component={NaverLoginProcess} />
+              <Route exact path="/calendar" component={CalendarPage} />
+              <Route exact path="/transaction" component={TransactionPage} />
+              <Route exact path="/chart" component={ChartPage} />
+            </Switch>
+          </Router>
+        </PaymentProvider>
+        {/* </AccountBookProvider> */}
       </TransactionInfoProvider>
     </DateInfoProvider>
   );

--- a/FE/src/components/AccountBook/AccountBookAddForm/accountBookAddForm.scss
+++ b/FE/src/components/AccountBook/AccountBookAddForm/accountBookAddForm.scss
@@ -1,0 +1,30 @@
+.create__acbook {
+  background-color: #f9e000;
+  height: 200px;
+  width: 340px;
+  margin: 20px 0px 20px 0px;
+  border: 1px solid transparent;
+  border-radius: 15px;
+  padding: 16px;
+  transition-duration: 0.3s;
+  transform: translateX(20%);
+  margin-bottom: 56px;
+
+  > input {
+    height: 30px;
+    width: 260px;
+    text-decoration: none;
+    margin: 5px;
+  }
+
+  > textarea {
+    height: 70px;
+    width: 260px;
+    margin: 5px;
+  }
+
+  .create__cancle {
+    cursor: pointer;
+    width: 0px;
+  }
+}

--- a/FE/src/components/AccountBook/AccountBookAddForm/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookAddForm/index.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import { postFetch } from '../../../service/fetch';
+import './accountBookAddForm.scss';
+
+export default function AccountBookAddForm({
+  create,
+  setCreate,
+  datas,
+  setDatas,
+}) {
+  const accountBookInput = useRef();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const onCreateAccountBook = event => {
+    if (event.key === 'Enter') {
+      const accountBookBody = {
+        name,
+        description,
+      };
+      //   const response = postFetch(
+      //     `${process.env.SERVER_URL}/api/accountbook`,
+      // accountBookBody,
+      //   );
+      setCreate(false);
+      setName('');
+      setDescription('');
+      setDatas([{ name, description }, ...datas]);
+    }
+  };
+
+  const onChangeName = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value);
+  };
+
+  const onChangeDescription = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDescription(event.target.value);
+  };
+
+  const cancleCreate = () => {
+    setCreate(false);
+  };
+
+  return (
+    <>
+      {create ? (
+        <div className="create__acbook">
+          <input
+            className="input__name"
+            ref={accountBookInput}
+            value={name}
+            type="text"
+            name="title"
+            placeholder="Enter AccountBook Title"
+            onKeyPress={onCreateAccountBook}
+            onChange={onChangeName}
+          />
+          <textarea
+            className="input__description"
+            value={description}
+            type="text"
+            name="description"
+            placeholder="Enter AccountBook Description"
+            onKeyPress={onCreateAccountBook}
+            onChange={onChangeDescription}
+          />
+          <p className="create__cancle" onClick={cancleCreate}>
+            Cancle
+          </p>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/FE/src/components/AccountBook/AccountBookControl/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookControl/index.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 import { PlusCircleIcon } from '@primer/octicons-react';
 
-import './AccountBookControl.scss';
+import './accountBookControl.scss';
 import { AccountBookContext } from '../../../store/AccountBook/account-book.context.tsx';
 import { useAccountBookData } from '../../../store/AccountBook/account-book.hook';
 
-export default function AccountBookControl() {
+export default function AccountBookControl({ setCreate }) {
   const store = React.useContext(AccountBookContext);
   // const isCreate = useAccountBookData(store => store.create);
 
   const createAccountBook = () => {
-    store.create = true;
+    setCreate(true);
   };
 
   return (

--- a/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
+++ b/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
@@ -1,90 +1,37 @@
-.acbook__list {
-  margin-left: auto;
+.delete__button {
+  z-index: 1;
+  transform: translate(80px, -60px);
+  animation: cardShow 0.5s;
+}
 
-  div:nth-child(1) {
-    animation: cardShow 0.5s;
-  }
-  div:nth-child(2) {
-    animation: cardShow 0.6s;
-  }
-  div:nth-child(3) {
-    animation: cardShow 0.7s;
-  }
-  div:nth-child(4) {
-    animation: cardShow 0.8s;
-  }
-  div:nth-child(5) {
-    animation: cardShow 0.9s;
-  }
-  div:nth-child(6) {
-    animation: cardShow 1.1s;
-  }
+.acbook {
+  background-color: #f9e000;
+  height: 200px;
+  width: 340px;
+  margin: 20px 0px 20px 0px;
+  border: 1px solid transparent;
+  border-radius: 15px;
+  padding: 16px;
+  transition-duration: 0.3s;
+  transform: translateX(20%);
+  color: black;
+  cursor: pointer;
 
-  .delete__button {
-    z-index: 1;
-    transform: translate(80px, -60px);
-    animation: cardShow 0.5s;
-  }
-
-  .create__acbook {
-    background-color: #f9e000;
-    height: 200px;
-    width: 340px;
-    margin: 20px 0px 20px 0px;
-    border: 1px solid transparent;
-    border-radius: 15px;
-    padding: 16px;
+  &:hover {
+    transform: translateX(5%);
     transition-duration: 0.3s;
-    transform: translateX(20%);
-
-    > input {
-      height: 30px;
-      width: 260px;
-      text-decoration: none;
-      margin: 5px;
-    }
-
-    > textarea {
-      height: 70px;
-      width: 260px;
-      margin: 5px;
-    }
-
-    .create__cancle {
-      cursor: pointer;
-      width: 0px;
-    }
+    transition-timing-function: ease, ease;
   }
 
-  .acbook {
-    background-color: #f9e000;
-    height: 200px;
-    width: 340px;
-    margin: 20px 0px 20px 0px;
-    border: 1px solid transparent;
-    border-radius: 15px;
-    padding: 16px;
-    transition-duration: 0.3s;
-    transform: translateX(20%);
-    color: black;
-    cursor: pointer;
-
-    &:hover {
-      transform: translateX(5%);
-      transition-duration: 0.3s;
-      transition-timing-function: ease, ease;
+  @keyframes cardShow {
+    from {
+      opacity: 0;
+      transform: translateX(300px);
     }
 
-    @keyframes cardShow {
-      from {
-        opacity: 0;
-        transform: translateX(300px);
-      }
-
-      to {
-        opacity: 1;
-        transform: 0;
-      }
+    to {
+      opacity: 1;
+      transform: 0;
     }
   }
 }

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -1,133 +1,51 @@
-import React, { ReactElement, useEffect, useRef, useState } from 'react';
-import { useObserver } from 'mobx-react-lite';
+import React, { ReactElement, useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import { AccountBookContext } from '../../../store/AccountBook/account-book.context.tsx';
-import './AccountBookList.scss';
+import getAccountBookList from '../../../api/accoun-book-list';
+import './accountBookList.scss';
 import { postFetch } from '../../../service/fetch';
-import { useAccountBookData } from '../../../store/AccountBook/account-book.hook';
 
-export const AccountBookView: ReactElement<{
-  datas: any[];
-}> = ({ datas }) => {
-  console.log('observe');
-  const store = React.useContext(AccountBookContext);
+export const AccountBookList = ({ datas, setDatas }) => {
+  const setAccountBookList = async () => {
+    const data = await getAccountBookList();
+    setDatas(data);
+  };
+
   const history = useHistory();
   const linkToDetail = (id = '') => {
     history.push(`calendar/${id}`);
   };
 
   const deleteAccountBook = (id = '') => {
-    datas = datas.filter(data => data._id !== id);
-    console.log(datas);
-    store.array = datas;
-  };
-
-  return (
-    <>
-      {datas.map(data => (
-        <>
-          <div className="acbook" onClick={() => linkToDetail()}>
-            <h3>{data.name}</h3>
-            <p>{data.description}</p>
-          </div>
-          <button
-            className="delete__button"
-            onClick={() => deleteAccountBook(data._id)}
-          >
-            Delete
-          </button>
-        </>
-      ))}
-    </>
-  );
-};
-
-export const AccountBookList = () => {
-  const store = React.useContext(AccountBookContext);
-  const accountBookInput = useRef();
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
-  const [datas, setDatas] = useState([]);
-
-  const accountBookData = useAccountBookData(store => store.accountBooks);
-  console.log(accountBookData);
-
-  const getAccountBookList = async () => {
-    const data = await accountBookData;
-    console.log(data);
-    setDatas(data);
-    store.array = data;
-  };
-
-  const onCreateAccountBook = event => {
-    if (event.key === 'Enter') {
-      const accountBookBody = {
-        name,
-        description,
-        transaction: [],
-      };
-      // postFetch(`${process.env.BACKEND}/api/accountbook`, accountBookBody);
-      store.create = false;
-      setName('');
-      setDescription('');
-      setDatas([{ name, description, transaction: [] }, ...datas]);
-      store.array = [{ name, description, transaction: [] }, ...datas];
-    }
-  };
-
-  const onChangeName = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setName(event.target.value);
-  };
-
-  const onChangeDescription = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setDescription(event.target.value);
-  };
-
-  const cancleCreate = () => {
-    store.create = false;
+    setDatas(datas.filter(data => data._id !== id));
   };
 
   useEffect(() => {
-    console.log('useEffect');
-    getAccountBookList();
+    setAccountBookList();
   }, []);
 
-  if (!store) throw Error("Store shouldn't be null");
-
-  return useObserver(() => {
-    return (
-      <div className="acbook__list">
-        {store.create ? (
-          <div className="create__acbook">
-            <input
-              className="input__name"
-              ref={accountBookInput}
-              value={name}
-              type="text"
-              name="title"
-              placeholder="Enter AccountBook Title"
-              onKeyPress={onCreateAccountBook}
-              onChange={onChangeName}
-            />
-            <textarea
-              className="input__description"
-              value={description}
-              type="text"
-              name="description"
-              placeholder="Enter AccountBook Description"
-              onKeyPress={onCreateAccountBook}
-              onChange={onChangeDescription}
-            />
-            <p className="create__cancle" onClick={cancleCreate}>
-              Cancle
-            </p>
-          </div>
-        ) : null}
-        {datas ? <AccountBookView datas={store.array} /> : null}
-      </div>
-    );
-  });
+  return (
+    <>
+      {datas ? (
+        <>
+          {datas.map(data => (
+            <>
+              <div className="acbook" onClick={() => linkToDetail()}>
+                <h3>{data.name}</h3>
+                <p>{data.description}</p>
+              </div>
+              <button
+                className="delete__button"
+                onClick={() => deleteAccountBook(data._id)}
+              >
+                Delete
+              </button>
+            </>
+          ))}
+        </>
+      ) : null}
+    </>
+  );
 };
 
 export default AccountBookList;

--- a/FE/src/pages/AccountBook/AccountBookListPage.scss
+++ b/FE/src/pages/AccountBook/AccountBookListPage.scss
@@ -2,4 +2,27 @@
   display: flex;
   flex-direction: row;
   padding: 90px 60px;
+
+  .acbook__list {
+    margin-left: auto;
+
+    div:nth-child(1) {
+      animation: cardShow 0.5s;
+    }
+    div:nth-child(2) {
+      animation: cardShow 0.6s;
+    }
+    div:nth-child(3) {
+      animation: cardShow 0.7s;
+    }
+    div:nth-child(4) {
+      animation: cardShow 0.8s;
+    }
+    div:nth-child(5) {
+      animation: cardShow 0.9s;
+    }
+    div:nth-child(6) {
+      animation: cardShow 1.1s;
+    }
+  }
 }

--- a/FE/src/pages/AccountBook/index.tsx
+++ b/FE/src/pages/AccountBook/index.tsx
@@ -1,14 +1,30 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import AccountBookControl from '../../components/AccountBook/AccountBookControl';
 import AccountBookList from '../../components/AccountBook/AccountBookList';
-import './AccountBookListPage.scss';
+import AccountBookAddForm from '../../components/AccountBook/AccountBookAddForm';
+import useLoginChcek from '../../service/useLoginCheck';
+
+import './accountBookListPage.scss';
 
 export default function AccountBookListPage() {
+  const [isCreate, setIsCreate] = useState(false);
+  const [listDatas, setListDatas] = useState([]);
+
+  useLoginChcek();
+
   return (
     <div className="acbook__list__container">
-      <AccountBookControl />
-      <AccountBookList />
+      <AccountBookControl setCreate={setIsCreate} />
+      <div className="acbook__list">
+        <AccountBookAddForm
+          create={isCreate}
+          setCreate={setIsCreate}
+          datas={listDatas}
+          setDatas={setListDatas}
+        />
+        <AccountBookList datas={listDatas} setDatas={setListDatas} />
+      </div>
     </div>
   );
 }

--- a/FE/src/store/AccountBook/account-book.hook.ts
+++ b/FE/src/store/AccountBook/account-book.hook.ts
@@ -13,7 +13,6 @@ export const useStoreData = <Selection, ContextData, Store>(
 
   const store = storeSelector(value);
   return useObserver(() => {
-    console.log('obs', value, store);
     return dataSelector(store);
   });
 };


### PR DESCRIPTION


### 📕 Issue Number

Close #37 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 가계부 목록 페이지에서 mobX를 사용하기에는 단일페이지에서만 필요한 값들이 많고 컴포넌트의 깊이가 깊지않아서 useState가 낫다고 판단하여 변경
- [x] 가계부 목록페이지에 들어왔을 때 로그인 유무를 확인하여 login 페이지로 push 해주는 함수 적용
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
