### PR TITLE
[FE] 가계부 목록 페이지 수정 버튼, 폼 구현 및 리팩토링

### DIFF
--- a/FE/src/components/AccountBook/AccountBookAddForm/accountBookAddForm.scss
+++ b/FE/src/components/AccountBook/AccountBookAddForm/accountBookAddForm.scss
@@ -8,7 +8,6 @@
   padding: 16px;
   transition-duration: 0.3s;
   transform: translateX(20%);
-  margin-bottom: 56px;
 
   > input {
     height: 30px;

--- a/FE/src/components/AccountBook/AccountBookAddForm/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookAddForm/index.tsx
@@ -3,15 +3,18 @@ import React, { useEffect, useRef, useState } from 'react';
 import { postFetch } from '../../../service/fetch';
 import './accountBookAddForm.scss';
 
-export default function AccountBookAddForm({
-  create,
-  setCreate,
-  datas,
-  setDatas,
-}) {
+export default function AccountBookAddForm({ props }) {
+  const {
+    create,
+    setCreate,
+    datas,
+    setDatas,
+    name,
+    setName,
+    description,
+    setDescription,
+  } = props;
   const accountBookInput = useRef();
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
 
   const onCreateAccountBook = event => {
     if (event.key === 'Enter') {
@@ -19,10 +22,10 @@ export default function AccountBookAddForm({
         name,
         description,
       };
-      //   const response = postFetch(
-      //     `${process.env.SERVER_URL}/api/accountbook`,
-      // accountBookBody,
-      //   );
+      const response = postFetch(
+        `${process.env.SERVER_URL}/api/accountbook`,
+        accountBookBody,
+      );
       setCreate(false);
       setName('');
       setDescription('');

--- a/FE/src/components/AccountBook/AccountBookAddForm/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookAddForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 
 import { postFetch } from '../../../service/fetch';
 import './accountBookAddForm.scss';
@@ -44,6 +44,12 @@ export default function AccountBookAddForm({ props }) {
   const cancleCreate = () => {
     setCreate(false);
   };
+
+  useEffect(() => {
+    if (create) {
+      accountBookInput.current.focus();
+    }
+  });
 
   return (
     <>

--- a/FE/src/components/AccountBook/AccountBookControl/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookControl/index.tsx
@@ -6,9 +6,6 @@ import { AccountBookContext } from '../../../store/AccountBook/account-book.cont
 import { useAccountBookData } from '../../../store/AccountBook/account-book.hook';
 
 export default function AccountBookControl({ setCreate }) {
-  const store = React.useContext(AccountBookContext);
-  // const isCreate = useAccountBookData(store => store.create);
-
   const createAccountBook = () => {
     setCreate(true);
   };

--- a/FE/src/components/AccountBook/AccountBookControl/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookControl/index.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import { PlusCircleIcon } from '@primer/octicons-react';
 
 import './accountBookControl.scss';
-import { AccountBookContext } from '../../../store/AccountBook/account-book.context.tsx';
-import { useAccountBookData } from '../../../store/AccountBook/account-book.hook';
 
 export default function AccountBookControl({ setCreate }) {
   const createAccountBook = () => {

--- a/FE/src/components/AccountBook/AccountBookEditButton/accountBookEditButton.scss
+++ b/FE/src/components/AccountBook/AccountBookEditButton/accountBookEditButton.scss
@@ -1,0 +1,4 @@
+.edit__cancle {
+  cursor: pointer;
+  width: 0px;
+}

--- a/FE/src/components/AccountBook/AccountBookEditButton/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookEditButton/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import './accountBookEditButton.scss';
+
+export default function AccountBookEditButton({ data, props }) {
+  const { datas, setDatas, setName, setDescription } = props;
+
+  const editAccountBook = id => {
+    let newArr = [...datas];
+    newArr.map(accountBook => {
+      if (accountBook._id === id) {
+        accountBook['isEdit'] = true;
+      }
+    });
+    setName(data.name);
+    setDescription(data.description);
+    setDatas(newArr);
+  };
+
+  return (
+    <button className="edit__button" onClick={() => editAccountBook(data._id)}>
+      Edit
+    </button>
+  );
+}

--- a/FE/src/components/AccountBook/AccountBookEditForm/accountBookEditForm.scss
+++ b/FE/src/components/AccountBook/AccountBookEditForm/accountBookEditForm.scss
@@ -1,0 +1,29 @@
+.edit__acbook {
+  background-color: #f9e000;
+  height: 200px;
+  width: 340px;
+  margin: 20px 0px 20px 0px;
+  border: 1px solid transparent;
+  border-radius: 15px;
+  padding: 16px;
+  transition-duration: 0.3s;
+  transform: translateX(20%);
+
+  > input {
+    height: 30px;
+    width: 260px;
+    text-decoration: none;
+    margin: 5px;
+  }
+
+  > textarea {
+    height: 70px;
+    width: 260px;
+    margin: 5px;
+  }
+
+  .edit__cancle {
+    cursor: pointer;
+    width: 0px;
+  }
+}

--- a/FE/src/components/AccountBook/AccountBookEditForm/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookEditForm/index.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useRef } from 'react';
+
+export default function AccountBookEditForm({ data, props }) {
+  const { datas, setDatas, name, setName, description, setDescription } = props;
+  const accountBookInput = useRef();
+
+  const onEditAccountBook = event => {
+    if (event.key === 'Enter') {
+      const id = event.target.dataset.id;
+      const accountBookBody = {
+        name,
+        description,
+      };
+      //   const response = updateFetch(
+      //     `${process.env.SERVER_URL}/api/accountbook/${id}`,
+      // accountBookBody,
+      //   );
+      let newArr = [...datas];
+      newArr.map(accountBook => {
+        if (accountBook._id === id) {
+          accountBook['isEdit'] = false;
+          accountBook['name'] = name;
+          accountBook['description'] = description;
+        }
+      });
+      setName('');
+      setDescription('');
+      setDatas(newArr);
+    }
+  };
+
+  const onChangeName = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setName(event.target.value);
+  };
+
+  const onChangeDescription = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setDescription(event.target.value);
+  };
+
+  const cancleEdit = id => {
+    let newArr = [...datas];
+    newArr.map(data => {
+      if (data._id === id) {
+        data['isEdit'] = false;
+      }
+    });
+    setDatas(newArr);
+  };
+
+  return (
+    <div className="edit__acbook">
+      <input
+        className="input__name"
+        ref={accountBookInput}
+        value={name}
+        type="text"
+        name="title"
+        onKeyPress={onEditAccountBook}
+        onChange={onChangeName}
+        data-id={data._id}
+      />
+      <textarea
+        className="input__description"
+        value={description}
+        type="text"
+        name="description"
+        onKeyPress={onEditAccountBook}
+        onChange={onChangeDescription}
+        data-id={data._id}
+      />
+      <p className="edit__cancle" onClick={() => cancleEdit(data._id)}>
+        Cancle
+      </p>
+    </div>
+  );
+}

--- a/FE/src/components/AccountBook/AccountBookEditForm/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookEditForm/index.tsx
@@ -1,4 +1,6 @@
-import React, { useState, useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
+
+import './accountBookEditForm.scss';
 
 export default function AccountBookEditForm({ data, props }) {
   const { datas, setDatas, name, setName, description, setDescription } = props;
@@ -46,6 +48,10 @@ export default function AccountBookEditForm({ data, props }) {
     });
     setDatas(newArr);
   };
+
+  useEffect(() => {
+    accountBookInput.current.focus();
+  }, []);
 
   return (
     <div className="edit__acbook">

--- a/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
+++ b/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
@@ -1,36 +1,3 @@
-.delete__button {
-}
-
-.edit__acbook {
-  background-color: #f9e000;
-  height: 200px;
-  width: 340px;
-  margin: 20px 0px 20px 0px;
-  border: 1px solid transparent;
-  border-radius: 15px;
-  padding: 16px;
-  transition-duration: 0.3s;
-  transform: translateX(20%);
-
-  > input {
-    height: 30px;
-    width: 260px;
-    text-decoration: none;
-    margin: 5px;
-  }
-
-  > textarea {
-    height: 70px;
-    width: 260px;
-    margin: 5px;
-  }
-
-  .edit__cancle {
-    cursor: pointer;
-    width: 0px;
-  }
-}
-
 .acbook {
   background-color: #f9e000;
   height: 200px;
@@ -43,6 +10,7 @@
   transform: translateX(20%);
   color: black;
   cursor: pointer;
+  animation: accountBookShow 1s backwards;
 
   &:hover {
     transform: translateX(5%);
@@ -50,7 +18,7 @@
     transition-timing-function: ease, ease;
   }
 
-  @keyframes cardShow {
+  @keyframes accountBookShow {
     from {
       opacity: 0;
       transform: translateX(300px);

--- a/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
+++ b/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
@@ -1,7 +1,34 @@
 .delete__button {
-  z-index: 1;
-  transform: translate(80px, -60px);
-  animation: cardShow 0.5s;
+}
+
+.edit__acbook {
+  background-color: #f9e000;
+  height: 200px;
+  width: 340px;
+  margin: 20px 0px 20px 0px;
+  border: 1px solid transparent;
+  border-radius: 15px;
+  padding: 16px;
+  transition-duration: 0.3s;
+  transform: translateX(20%);
+
+  > input {
+    height: 30px;
+    width: 260px;
+    text-decoration: none;
+    margin: 5px;
+  }
+
+  > textarea {
+    height: 70px;
+    width: 260px;
+    margin: 5px;
+  }
+
+  .edit__cancle {
+    cursor: pointer;
+    width: 0px;
+  }
 }
 
 .acbook {

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -1,22 +1,31 @@
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect, useState, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import getAccountBookList from '../../../api/accoun-book-list';
 import './accountBookList.scss';
-import { postFetch } from '../../../service/fetch';
+import AccountBookEditButton from '../AccountBookEditButton';
+import AccountBookEditForm from '../AccountBookEditForm';
 
-export const AccountBookList = ({ datas, setDatas }) => {
+export const AccountBookList = ({ props }) => {
+  const { datas, setDatas } = props;
+
   const setAccountBookList = async () => {
-    const data = await getAccountBookList();
-    setDatas(data);
+    const accountBookDatas = await getAccountBookList();
+
+    accountBookDatas.map(data => (data.isEdit = false));
+    setDatas(accountBookDatas);
   };
 
   const history = useHistory();
-  const linkToDetail = (id = '') => {
-    history.push(`calendar/${id}`);
+
+  const linkToDetail = event => {
+    const targetClass = event.target.className;
+    if (targetClass !== 'delete__button' && targetClass !== 'edit__button') {
+      history.push(`calendar`);
+    }
   };
 
-  const deleteAccountBook = (id = '') => {
+  const deleteAccountBook = id => {
     setDatas(datas.filter(data => data._id !== id));
   };
 
@@ -26,24 +35,27 @@ export const AccountBookList = ({ datas, setDatas }) => {
 
   return (
     <>
-      {datas ? (
-        <>
-          {datas.map(data => (
+      {datas.map((data, index) => (
+        <div key={index}>
+          {!data.isEdit ? (
             <>
-              <div className="acbook" onClick={() => linkToDetail()}>
+              <div className="acbook" onClick={linkToDetail}>
                 <h3>{data.name}</h3>
                 <p>{data.description}</p>
+                <button
+                  className="delete__button"
+                  onClick={event => deleteAccountBook(data._id, event)}
+                >
+                  Delete
+                </button>
+                <AccountBookEditButton data={data} props={props} />
               </div>
-              <button
-                className="delete__button"
-                onClick={() => deleteAccountBook(data._id)}
-              >
-                Delete
-              </button>
             </>
-          ))}
-        </>
-      ) : null}
+          ) : (
+            <AccountBookEditForm data={data} props={props} />
+          )}
+        </div>
+      ))}
     </>
   );
 };

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useEffect, useState, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import getAccountBookList from '../../../api/accoun-book-list';

--- a/FE/src/pages/AccountBook/AccountBookListPage.scss
+++ b/FE/src/pages/AccountBook/AccountBookListPage.scss
@@ -5,24 +5,5 @@
 
   .acbook__list {
     margin-left: auto;
-
-    div:nth-child(1) {
-      animation: cardShow 0.5s;
-    }
-    div:nth-child(2) {
-      animation: cardShow 0.6s;
-    }
-    div:nth-child(3) {
-      animation: cardShow 0.7s;
-    }
-    div:nth-child(4) {
-      animation: cardShow 0.8s;
-    }
-    div:nth-child(5) {
-      animation: cardShow 0.9s;
-    }
-    div:nth-child(6) {
-      animation: cardShow 1.1s;
-    }
   }
 }

--- a/FE/src/pages/AccountBook/index.tsx
+++ b/FE/src/pages/AccountBook/index.tsx
@@ -8,22 +8,30 @@ import useLoginChcek from '../../service/useLoginCheck';
 import './accountBookListPage.scss';
 
 export default function AccountBookListPage() {
-  const [isCreate, setIsCreate] = useState(false);
-  const [listDatas, setListDatas] = useState([]);
+  const [create, setCreate] = useState(false);
+  const [datas, setDatas] = useState([]);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const props = {
+    create,
+    datas,
+    name,
+    description,
+    setCreate,
+    setDatas,
+    setName,
+    setDescription,
+  };
 
   useLoginChcek();
 
   return (
     <div className="acbook__list__container">
-      <AccountBookControl setCreate={setIsCreate} />
+      <AccountBookControl setCreate={setCreate} />
       <div className="acbook__list">
-        <AccountBookAddForm
-          create={isCreate}
-          setCreate={setIsCreate}
-          datas={listDatas}
-          setDatas={setListDatas}
-        />
-        <AccountBookList datas={listDatas} setDatas={setListDatas} />
+        <AccountBookAddForm props={props} />
+        <AccountBookList props={props} />
       </div>
     </div>
   );


### PR DESCRIPTION
### 📕 Issue Number

Close #37 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역
- [x] 가계부 수정 버튼 클릭 시 수정 폼 형태로 바뀌게 구현 수정 폼에는 기존의 데이터가 들어가 있음
- [x] 최상단에서 useState로 선언한 값들을 props라는 객체로 하위컴포넌트에 전달하게 리팩토링
  구조분해할당으로 props를 전달해주고 싶지만 함수형 컴포넌트의 props는 구조분해할당을 할 수 없기에 객체로 전달
- [x] 가계부의 edit, delete 버튼 클릭 시 페이지가 이동되지 않도록 페이지 이동 onClick 함수에 event.target.className 이 delete 버튼과 edit 버튼이면 이동하지 않도록 적용
- [x] 추가, 수정 시 name input에 커서가 focus 되도록 구현
- [x] 현재는 API가 완성되지 않은 부분이 있어서 수정과 삭제는 API 요청을 뺀 스토어에서만 이루어지는 상태로 구현

<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>