### PR TITLE
payement, accountbook Api connect

### DIFF
--- a/FE/src/api/payment-method.ts
+++ b/FE/src/api/payment-method.ts
@@ -1,6 +1,6 @@
 import { postFetch, updateFetch, deleteFetch } from '../service/fetch';
 
-export const postPaymentMethod = ({ accountBookId, name, desc, color }) => {
+export const createPaymentMethod = ({ accountBookId, name, desc, color }) => {
   const data = postFetch(
     `${process.env.SERVER_URL}/api/accountbook/${accountBookId}/payment`,
     {

--- a/FE/src/api/payment-method.ts
+++ b/FE/src/api/payment-method.ts
@@ -14,14 +14,14 @@ export const createPaymentMethod = ({ accountBookId, name, desc, color }) => {
 };
 
 export const updatePaymentMethod = ({
-  accountBookdId,
+  accountBookId,
   paymentId,
   name,
   desc,
   color,
 }) => {
   const res = updateFetch(
-    `${process.env.SERVER_URL}/api/accountbook/${accountBookdId}/payment/${paymentId}`,
+    `${process.env.SERVER_URL}/api/accountbook/${accountBookId}/payment/${paymentId}`,
     {
       name,
       desc,

--- a/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
+++ b/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
@@ -27,10 +27,39 @@
     .ac__title {
       font-size: 1.5em;
       font-weight: bold;
+      &.hidden {
+        display: none;
+      }
     }
     .ac__desc {
       margin-top: 2em;
       font-weight: 900;
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .acbook__title__input {
+      position: absolute;
+      top: 2.2em;
+      height: 2em;
+      width: 230px;
+      text-decoration: none;
+
+      &.hidden {
+        display: none;
+      }
+    }
+    .acbook__desc__input {
+      position: absolute;
+      top: 5.5em;
+      height: 5em;
+      width: 230px;
+
+      resize: none;
+      &.hidden {
+        display: none;
+      }
     }
 
     .fas.fa-edit {

--- a/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
+++ b/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
@@ -32,10 +32,23 @@
       margin-top: 2em;
       font-weight: 900;
     }
+
+    .fas.fa-edit {
+      z-index: 2;
+      font-size: 1.3em;
+      top: 1.5em;
+      right: 1em;
+      position: absolute;
+
+      &:hover {
+        color: $spending-color;
+      }
+    }
+
     .fas.fa-trash-alt {
       z-index: 2;
       font-size: 1.5em;
-      top: 1.5em;
+      top: 3em;
       right: 1em;
       position: absolute;
 

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -58,6 +58,7 @@ export const AccountBookList = ({ datas, setDatas }) => {
             {data.description}
           </div>
 
+          <i className="fas fa-edit" data-id={data._id} />
           <i
             className="fas fa-trash-alt"
             data-id={data._id}

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, isValidElement } from 'react';
+import React, { useEffect } from 'react';
 
 import { useHistory } from 'react-router-dom';
 
 import {
   getAccountBookList,
+  updateAccountBook,
   deleteAccountBook,
 } from '../../../api/accoun-book-list';
+
+import { findSibling } from '../../../util/findSibling';
 import './accountBookList.scss';
 
 export const AccountBookList = ({ datas, setDatas }) => {
@@ -19,8 +22,56 @@ export const AccountBookList = ({ datas, setDatas }) => {
     setDatas(accountBooks.data);
   };
 
+  const onClickModify = event => {
+    const title = findSibling(event.target, 'ac__title');
+    const desc = findSibling(event.target, 'ac__desc');
+    const titleEdit = findSibling(event.target, 'acbook__title__input');
+    const descEdit = findSibling(event.target, 'acbook__desc__input');
+
+    titleEdit.value = title.textContent;
+    descEdit.value = desc.textContent;
+
+    title.classList.toggle('hidden');
+    desc.classList.toggle('hidden');
+    titleEdit.classList.toggle('hidden');
+    descEdit.classList.toggle('hidden');
+    titleEdit.focus();
+  };
+
+  const onEnterEditForm = async event => {
+    const title = findSibling(event.target, 'ac__title');
+    const desc = findSibling(event.target, 'ac__desc');
+    const titleEdit = findSibling(event.target, 'acbook__title__input');
+    const descEdit = findSibling(event.target, 'acbook__desc__input');
+
+    if (event.key === 'Enter') {
+      await updateAccountBook({
+        accountBookId: event.target.dataset.acbookid,
+        name: titleEdit.value,
+        description: descEdit.value,
+      });
+
+      const updatedAcBooks = datas.map(item => {
+        if (item._id === event.target.dataset.acbookid) {
+          item = {
+            ...item,
+            name: titleEdit.value,
+            description: descEdit.value,
+          };
+          return item;
+        }
+      });
+
+      setDatas(() => updatedAcBooks);
+      title.classList.toggle('hidden');
+      desc.classList.toggle('hidden');
+      titleEdit.classList.toggle('hidden');
+      descEdit.classList.toggle('hidden');
+    }
+  };
+
   const linkToDetail = async event => {
-    if (!event.target.classList.contains('fa-trash-alt')) {
+    if (event.target.className === 'acbook') {
       history.push({
         pathname: '/calendar',
         state: {
@@ -58,7 +109,22 @@ export const AccountBookList = ({ datas, setDatas }) => {
             {data.description}
           </div>
 
-          <i className="fas fa-edit" data-id={data._id} />
+          <input
+            className="acbook__title__input hidden"
+            data-acbookid={data._id}
+            onKeyPress={onEnterEditForm}
+          />
+          <textarea
+            className="acbook__desc__input hidden"
+            data-acbookid={data._id}
+            onKeyPress={onEnterEditForm}
+          />
+
+          <i
+            className="fas fa-edit"
+            data-id={data._id}
+            onClick={onClickModify}
+          />
           <i
             className="fas fa-trash-alt"
             data-id={data._id}

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -71,7 +71,7 @@ export const AccountBookList = ({ datas, setDatas }) => {
   };
 
   const linkToDetail = async event => {
-    if (event.target.className === 'acbook') {
+    if (event.target.classList.contains('link')) {
       history.push({
         pathname: '/calendar',
         state: {
@@ -97,15 +97,15 @@ export const AccountBookList = ({ datas, setDatas }) => {
       {datas.map((data, index) => (
         <div
           key={data._id}
-          className="acbook"
+          className="acbook link"
           data-acbookid={data._id}
           onClick={linkToDetail}
           style={{ animationDelay: `${index * 0.08}s` }}
         >
-          <div className="ac__title" data-acbookid={data._id}>
+          <div className="ac__title link" data-acbookid={data._id}>
             {data.name}
           </div>
-          <div className="ac__desc" data-acbookid={data._id}>
+          <div className="ac__desc link" data-acbookid={data._id}>
             {data.description}
           </div>
 

--- a/FE/src/components/Calendar/CalendarBody/calendarBody.scss
+++ b/FE/src/components/Calendar/CalendarBody/calendarBody.scss
@@ -10,6 +10,7 @@ td {
   .income__info {
     font-size: 0.8em;
     color: $income-color;
+    // padding-top: 1em;
   }
   .spending__info {
     font-size: 0.8em;
@@ -21,6 +22,7 @@ td {
   background-color: #222;
   border-radius: 6px;
   position: relative;
+
   cursor: pointer;
   &:hover {
     animation: dateHover 1s;

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -30,10 +30,14 @@
     border: 1px solid #979797;
     color: #979797;
 
-    animation: detailFormShow 1s;
+    animation: detailFormShow 1s ease;
     @keyframes detailFormShow {
       from {
+        opacity: 0;
         transform: translateY(500px);
+      }
+      to {
+        opacity: 1;
       }
     }
 
@@ -62,12 +66,15 @@
         background-color: #333;
         color: #979797;
         position: relative;
-        animation: specificDataShow 1s;
+        animation: specificDataShow 1s backwards;
 
         @keyframes specificDataShow {
           from {
             opacity: 0;
             transform: translateX(-100px);
+          }
+          to {
+            opacity: 1;
           }
         }
         .specific__content {

--- a/FE/src/components/PaymentMethod/AddTemplate/index.tsx
+++ b/FE/src/components/PaymentMethod/AddTemplate/index.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect, useContext, useState } from 'react';
 import { useTransactionData } from '../../../store/AccountBook/accountBookInfoHook';
-import { paymentContext } from '../../../store/PaymentMethod/paymentMethodContext';
 import { useRootData } from '../../../store/PaymentMethod/paymentMethodHook';
 
+import { createPaymentMethod } from '../../../api/payment-method';
 import './addForm.scss';
 
 interface Card {
@@ -14,22 +14,27 @@ export default function AddTemplate({
 }: Card): React.ReactElement {
   const [methodNick, setMethodNick] = useState('');
   const methodInput = useRef();
-  const store = useContext(paymentContext);
+
   const addTemplateData = useRootData(store => store.addTemplateData);
-  const addPaymentMethod = useTransactionData(store => store.addPaymentMethod);
   const updateAddTemplate = useRootData(store => store.updateAddTemplate);
+
+  const addPaymentMethod = useTransactionData(store => store.addPaymentMethod);
+  const accountBookId = useTransactionData(store => store.accountBook._id);
 
   const onChangeNick = (event: React.ChangeEvent<HTMLInputElement>) => {
     setMethodNick(event.target.value);
   };
 
-  const onAddCard = event => {
+  const onAddCard = async event => {
     if (event.key === 'Enter') {
-      addPaymentMethod({
+      const res = await createPaymentMethod({
+        accountBookId,
         name: addTemplateData.name,
         desc: `${methodNick}`,
         color: addTemplateData.color,
       });
+
+      addPaymentMethod(res.data);
 
       setAddFormModal(() => false);
       updateAddTemplate({ name: '', color: '' });

--- a/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
+++ b/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
@@ -28,11 +28,6 @@
     border-radius: 6px;
     padding: 1.5em;
 
-    .card__cancel {
-      position: absolute;
-      right: 1.5em;
-      top: 1em;
-    }
     .card__title {
       font-size: 2em;
       padding: 0.2em 0;
@@ -41,6 +36,28 @@
 
     .card__desc {
       font-size: 1.2em;
+    }
+
+    .fas.fa-trash-alt {
+      position: absolute;
+      right: 1.2em;
+      top: 1.5em;
+      font-size: 1.5em;
+
+      &:hover {
+        color: black;
+
+        animation: deleteBtn 1s forwards;
+
+        @keyframes deleteBtn {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      }
     }
 
     &:hover {

--- a/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
+++ b/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
@@ -36,12 +36,46 @@
 
     .card__desc {
       font-size: 1.2em;
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .desc__input {
+      width: 200px;
+      text-decoration: none;
+
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .fas.fa-edit {
+      position: absolute;
+      right: 1em;
+      top: 1.5em;
+      font-size: 1.5em;
+
+      &:hover {
+        color: black;
+
+        animation: deleteBtn 1s forwards;
+
+        @keyframes deleteBtn {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      }
     }
 
     .fas.fa-trash-alt {
       position: absolute;
       right: 1.2em;
-      top: 1.5em;
+      top: 3.5em;
       font-size: 1.5em;
 
       &:hover {

--- a/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
+++ b/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
@@ -13,6 +13,7 @@
   overflow-x: hidden;
   flex: 1;
   z-index: 2;
+  margin-top: 3em;
 
   .card__container__card {
     position: relative;

--- a/FE/src/components/PaymentMethod/CardContainer/index.tsx
+++ b/FE/src/components/PaymentMethod/CardContainer/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { v4 } from 'uuid';
 
 import { useTransactionData } from '../../../store/AccountBook/accountBookInfoHook';
-import { deletePaymentMethod } from '../../../api/payment-method';
+import {
+  updatePaymentMethod,
+  deletePaymentMethod,
+} from '../../../api/payment-method';
 import './cardContainer.scss';
 
 export default React.memo(function CardContainer(): React.ReactElement {
@@ -10,10 +12,44 @@ export default React.memo(function CardContainer(): React.ReactElement {
   const paymentMethods = useTransactionData(
     store => store.accountBook.payments,
   );
+  const updatePayment = useTransactionData(store => store.updatePaymentMethod);
   const deletePayment = useTransactionData(store => store.deletePaymentMethod);
 
+  const onClickModify = event => {
+    const editForm = event.target.previousSibling;
+    const content = editForm.previousSibling;
+
+    editForm.value = content.textContent;
+
+    editForm.classList.toggle('hidden');
+    content.classList.toggle('hidden');
+
+    editForm.focus();
+  };
+
+  const onEnterEditForm = async event => {
+    const content = event.target.previousSibling;
+
+    if (event.key === 'Enter') {
+      await updatePaymentMethod({
+        accountBookId,
+        paymentId: event.target.dataset.cardid,
+        name: event.target.dataset.name,
+        desc: event.target.value,
+        color: event.target.dataset.color,
+      });
+
+      updatePayment({
+        id: event.target.dataset.cardid,
+        desc: event.target.value,
+      });
+      event.target.classList.toggle('hidden');
+      content.classList.toggle('hidden');
+    }
+  };
+
   const onClickDelete = async event => {
-    const res = await deletePaymentMethod({
+    await deletePaymentMethod({
       accountBookId,
       paymentId: event.target.dataset.cardid,
     });
@@ -25,7 +61,7 @@ export default React.memo(function CardContainer(): React.ReactElement {
     <div className="card__container" data-overlay>
       {paymentMethods.map((card, i) => (
         <div
-          key={v4()}
+          key={card._id}
           className="card__container__card"
           style={{
             background: `${card.color}`,
@@ -34,6 +70,20 @@ export default React.memo(function CardContainer(): React.ReactElement {
         >
           <div className="card__title">{card.name}</div>
           <div className="card__desc">{card.desc}</div>
+
+          <input
+            className="desc__input hidden"
+            onKeyPress={onEnterEditForm}
+            data-cardid={card._id}
+            data-name={card.name}
+            data-color={card.color}
+          />
+
+          <i
+            className="fas fa-edit"
+            data-cardid={card._id}
+            onClick={onClickModify}
+          />
           <i
             className="fas fa-trash-alt"
             data-cardid={card._id}

--- a/FE/src/components/PaymentMethod/CardContainer/index.tsx
+++ b/FE/src/components/PaymentMethod/CardContainer/index.tsx
@@ -2,13 +2,24 @@ import React from 'react';
 import { v4 } from 'uuid';
 
 import { useTransactionData } from '../../../store/AccountBook/accountBookInfoHook';
-
+import { deletePaymentMethod } from '../../../api/payment-method';
 import './cardContainer.scss';
 
 export default React.memo(function CardContainer(): React.ReactElement {
+  const accountBookId = useTransactionData(store => store.accountBook._id);
   const paymentMethods = useTransactionData(
     store => store.accountBook.payments,
   );
+  const deletePayment = useTransactionData(store => store.deletePaymentMethod);
+
+  const onClickDelete = async event => {
+    const res = await deletePaymentMethod({
+      accountBookId,
+      paymentId: event.target.dataset.cardid,
+    });
+
+    deletePayment(event.target.dataset.cardid);
+  };
 
   return (
     <div className="card__container" data-overlay>
@@ -21,9 +32,13 @@ export default React.memo(function CardContainer(): React.ReactElement {
             animationDelay: `${i * 0.08}s`,
           }}
         >
-          <div className="card__cancel">X</div>
           <div className="card__title">{card.name}</div>
           <div className="card__desc">{card.desc}</div>
+          <i
+            className="fas fa-trash-alt"
+            data-cardid={card._id}
+            onClick={onClickDelete}
+          />
         </div>
       ))}
     </div>

--- a/FE/src/components/PaymentMethod/Modal/index.tsx
+++ b/FE/src/components/PaymentMethod/Modal/index.tsx
@@ -23,7 +23,7 @@ export default function PaymentModal({
   return (
     <>
       <div className="modal__wrapper" data-overlay onClick={onClickOverlay}>
-        <span className="title">Payment Method</span>
+        <span className="payment__title">Payment Method</span>
         <button type="button" onClick={onClickNew} className="new__button">
           Add
         </button>

--- a/FE/src/components/PaymentMethod/Modal/modal.scss
+++ b/FE/src/components/PaymentMethod/Modal/modal.scss
@@ -6,12 +6,12 @@
   width: 100%;
   height: 100%;
   background-color: $modal-background;
+  padding: 7em;
   z-index: 2;
-  .title {
+  .payment__title {
     display: inline-block;
     color: $white;
-    padding: 1em 2em;
-    font-size: 4rem;
+    font-size: 5em;
     width: 100%;
     text-shadow: $selectedTextShadow;
   }
@@ -21,8 +21,8 @@
     border: 1px solid $white;
     color: $white;
     position: absolute;
-    top: 10em;
-    left: 19em;
+    top: 15em;
+    left: 23em;
     width: 8em;
     height: 50px;
     background-color: $modal-button-background;

--- a/FE/src/service/fetch.ts
+++ b/FE/src/service/fetch.ts
@@ -26,7 +26,7 @@ export const postFetch = async (query, body) => {
 
 export const updateFetch = async (query, body) => {
   const response = await fetch(`${query}`, {
-    method: 'PUT',
+    method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${window.localStorage.getItem('token')}`,

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -16,7 +16,7 @@ export const createStore = () => {
 
     async setAccountBook(id) {
       const accountBook = await getTargetAccountBook(id);
-
+      accountBook.data.payments.reverse();
       this.accountBook = accountBook.data;
     },
 

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -24,6 +24,12 @@ export const createStore = () => {
       this.accountBook.payments = [data, ...this.accountBook.payments];
     },
 
+    deletePaymentMethod(id) {
+      this.accountBook.payments = this.accountBook.payments.filter(
+        payment => payment._id !== id,
+      );
+    },
+
     filterTransaction(
       category: string,
       year: number,

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -69,9 +69,6 @@ export const createStore = () => {
         return acc;
       }, {});
 
-      console.log(categoryFiltered);
-      console.log(transactionsGroupByDate);
-
       this.filteredTransactions = transactionsGroupByDate;
     },
 

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -25,7 +25,6 @@ export const createStore = () => {
     },
 
     updatePaymentMethod(data: { id: string; desc: string }) {
-      console.log(data.desc);
       const updatedPayments = [...this.accountBook.payments];
       updatedPayments = updatedPayments.map(item => {
         if (item._id === data.id) {
@@ -33,7 +32,6 @@ export const createStore = () => {
         }
         return item;
       });
-      console.log(updatedPayments[0].desc);
       this.accountBook.payments = updatedPayments;
     },
 

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -24,6 +24,19 @@ export const createStore = () => {
       this.accountBook.payments = [data, ...this.accountBook.payments];
     },
 
+    updatePaymentMethod(data: { id: string; desc: string }) {
+      console.log(data.desc);
+      const updatedPayments = [...this.accountBook.payments];
+      updatedPayments = updatedPayments.map(item => {
+        if (item._id === data.id) {
+          item = { ...item, desc: data.desc };
+        }
+        return item;
+      });
+      console.log(updatedPayments[0].desc);
+      this.accountBook.payments = updatedPayments;
+    },
+
     deletePaymentMethod(id) {
       this.accountBook.payments = this.accountBook.payments.filter(
         payment => payment._id !== id,

--- a/FE/src/util/findSibling.ts
+++ b/FE/src/util/findSibling.ts
@@ -1,0 +1,9 @@
+export const findSibling = (target, className) => {
+  const siblings = target.parentNode.childNodes;
+
+  for (let i = 0; i < siblings.length; i++) {
+    if (siblings[i].classList.contains(className)) {
+      return siblings[i];
+    }
+  }
+};


### PR DESCRIPTION
### 📕 Issue Number

Closes #92 #93  
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 가계부 update api 연동
- 영우님이 작성해주신 것 기반으로 로직 작성하였습니다.
- 다른점은 edit form자체를 분리하여 props를 넘겨주는 방식을
한 컴포넌트 내에서 조건부 렌더링을 사용하여, edit 버튼을 눌렀을 때는 edit form이 보이도록하고 수정이 완료되거나 edit을 취소했을 때는 다시 본래 내용이 나오도록 렌더링 해주었습니다.
- DB를 업데이트 시키고, 새로 fetch를 받기 보다는 업데이트가 되었다는 사실 확인 후 프론트 내에서 상태를 변화시켜 리렌더링 하도록 하였습니다.
(디테일 페이지에서의 각 탭과 같은 흐름입니다.)

- [x] 결제수단 create, update, delete api 연동
- 본래 dummy data를 쓰던 사용자 결제수단 데이터를 전역의 account book 데이터로부터 받아 사용하도록 변경하였습니다.
- account book안에 임베디드 된 데이터를 사용하기 때문에 따로 read api를 작성하지 않기로 하여 read는 연결하지 않았습니다.
- create, update, delete를 실행하면 디비를 변경시킨 후 따로 fetch를 받지 않고 store의 상태값을 변화시켜 리렌더링 하도록 하였습니다.

- [x] scss 리팩토링
- 가계부 목록 페이지와 결제수단 목록페이지가 동일한 구조를 띄고 있어서 title 크기나 위치, add버튼의 위치 등이 동일하도록 수정하였습니다.
- calendar detail modal의 animation이 부자연스러워서 opacity 0 -> opacity 1로 수정해주었습니다.
- 브랜치를 따로 파서 작업해야하는데 이렇게 조금씩 섞이게 되어서 죄송합니다 ㅠㅠ 

구제척인 동작 과정은 회의때 시연하여 보여드리겠습니다 !! ( front - back - front 흐름 !)


<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
