### PR TITLE
Create setting page

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -2950,6 +2950,32 @@
       "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
       "dev": true
     },
+    "chart.js": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+      "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
+      "requires": {
+        "chartjs-color": "^2.1.0",
+        "moment": "^2.10.2"
+      }
+    },
+    "chartjs-color": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+      "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
+      "requires": {
+        "chartjs-color-string": "^0.6.0",
+        "color-convert": "^1.9.3"
+      }
+    },
+    "chartjs-color-string": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+      "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+      "requires": {
+        "color-name": "^1.0.0"
+      }
+    },
     "chokidar": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
@@ -7291,6 +7317,11 @@
       "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-3.1.6.tgz",
       "integrity": "sha512-MM3x9BLt5nC7iE/ILA5n2+hfrplEKYbFjqROEuGkzBdZP/KD+Z44+2gseczRrTG0xFuiPWfEzgT68+6/zqOiEw=="
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -8564,6 +8595,15 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      }
+    },
+    "react-chartjs-2": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-2.11.1.tgz",
+      "integrity": "sha512-G7cNq/n2Bkh/v4vcI+GKx7Q1xwZexKYhOSj2HmrFXlvNeaURWXun6KlOUpEQwi1cv9Tgs4H3kGywDWMrX2kxfA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "prop-types": "^15.7.2"
       }
     },
     "react-dom": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -15,8 +15,10 @@
   "dependencies": {
     "@primer/octicons-react": "^11.1.0",
     "@svgr/webpack": "^5.5.0",
+    "chart.js": "^2.9.4",
     "mobx-react": "^7.0.5",
     "react": "^17.0.1",
+    "react-chartjs-2": "^2.11.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "sass": "^1.29.0",

--- a/FE/src/api/payment-method.ts
+++ b/FE/src/api/payment-method.ts
@@ -1,6 +1,6 @@
 import { postFetch, updateFetch, deleteFetch } from '../service/fetch';
 
-export const postPaymentMethod = ({ accountBookId, name, desc, color }) => {
+export const createPaymentMethod = ({ accountBookId, name, desc, color }) => {
   const data = postFetch(
     `${process.env.SERVER_URL}/api/accountbook/${accountBookId}/payment`,
     {

--- a/FE/src/api/payment-method.ts
+++ b/FE/src/api/payment-method.ts
@@ -14,14 +14,14 @@ export const createPaymentMethod = ({ accountBookId, name, desc, color }) => {
 };
 
 export const updatePaymentMethod = ({
-  accountBookdId,
+  accountBookId,
   paymentId,
   name,
   desc,
   color,
 }) => {
   const res = updateFetch(
-    `${process.env.SERVER_URL}/api/accountbook/${accountBookdId}/payment/${paymentId}`,
+    `${process.env.SERVER_URL}/api/accountbook/${accountBookId}/payment/${paymentId}`,
     {
       name,
       desc,

--- a/FE/src/app.scss
+++ b/FE/src/app.scss
@@ -13,12 +13,14 @@ body {
 }
 
 #root {
+  position: relative;
   width: 100%;
   height: 100%;
   margin: 0;
   padding: 0;
   font-family: 'Roboto', sans-serif;
   background-color: black;
+  overflow-x: hidden;
 }
 
 a {

--- a/FE/src/app.tsx
+++ b/FE/src/app.tsx
@@ -11,10 +11,11 @@ import AccountBookListPage from './pages/AccountBook';
 import CalendarPage from './pages/Calendar';
 import LoginPage from './pages/Login';
 import TransactionPage from './pages/Transaction';
+import ChartPage from './pages/Chart';
+import SettingPage from './pages/SettingPage';
 
 import GithubLoginProcess from './pages/Login/GithubLoginProcess';
 import NaverLoginProcess from './pages/Login/NaverLoginProcess';
-import ChartPage from './pages/Chart';
 
 const App = () => {
   return (
@@ -32,6 +33,7 @@ const App = () => {
               </Route>
               <Route exact path="/transaction" component={TransactionPage} />
               <Route exact path="/chart" component={ChartPage} />
+              <Route exact path="/setting" component={SettingPage} />
             </Switch>
           </Router>
         </PaymentProvider>

--- a/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
+++ b/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
@@ -27,10 +27,39 @@
     .ac__title {
       font-size: 1.5em;
       font-weight: bold;
+      &.hidden {
+        display: none;
+      }
     }
     .ac__desc {
       margin-top: 2em;
       font-weight: 900;
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .acbook__title__input {
+      position: absolute;
+      top: 2.2em;
+      height: 2em;
+      width: 230px;
+      text-decoration: none;
+
+      &.hidden {
+        display: none;
+      }
+    }
+    .acbook__desc__input {
+      position: absolute;
+      top: 5.5em;
+      height: 5em;
+      width: 230px;
+
+      resize: none;
+      &.hidden {
+        display: none;
+      }
     }
 
     .fas.fa-edit {

--- a/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
+++ b/FE/src/components/AccountBook/AccountBookList/AccountBookList.scss
@@ -32,10 +32,23 @@
       margin-top: 2em;
       font-weight: 900;
     }
+
+    .fas.fa-edit {
+      z-index: 2;
+      font-size: 1.3em;
+      top: 1.5em;
+      right: 1em;
+      position: absolute;
+
+      &:hover {
+        color: $spending-color;
+      }
+    }
+
     .fas.fa-trash-alt {
       z-index: 2;
       font-size: 1.5em;
-      top: 1.5em;
+      top: 3em;
       right: 1em;
       position: absolute;
 

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -8,7 +8,6 @@ import {
   deleteAccountBook,
 } from '../../../api/accoun-book-list';
 
-import { findSibling } from '../../../util/findSibling';
 import './accountBookList.scss';
 
 export const AccountBookList = ({ datas, setDatas }) => {
@@ -22,52 +21,54 @@ export const AccountBookList = ({ datas, setDatas }) => {
     setDatas(accountBooks.data);
   };
 
+  const titleRef = [];
+  const descRef = [];
+  const titleEditRef = [];
+  const descEditRef = [];
+  datas.forEach(() => {
+    titleRef.push(React.createRef());
+    descRef.push(React.createRef());
+    titleEditRef.push(React.createRef());
+    descEditRef.push(React.createRef());
+  });
+
   const onClickModify = event => {
-    const title = findSibling(event.target, 'ac__title');
-    const desc = findSibling(event.target, 'ac__desc');
-    const titleEdit = findSibling(event.target, 'acbook__title__input');
-    const descEdit = findSibling(event.target, 'acbook__desc__input');
+    const index = event.target.dataset.turn;
 
-    titleEdit.value = title.textContent;
-    descEdit.value = desc.textContent;
+    titleEditRef[index].current.value = titleRef[index].current.textContent;
+    descEditRef[index].current.value = descRef[index].current.textContent;
 
-    title.classList.toggle('hidden');
-    desc.classList.toggle('hidden');
-    titleEdit.classList.toggle('hidden');
-    descEdit.classList.toggle('hidden');
-    titleEdit.focus();
+    titleRef[index].current.classList.toggle('hidden');
+    descRef[index].current.classList.toggle('hidden');
+    titleEditRef[index].current.classList.toggle('hidden');
+    descEditRef[index].current.classList.toggle('hidden');
+    titleEditRef[index].current.focus();
   };
 
   const onEnterEditForm = async event => {
-    const title = findSibling(event.target, 'ac__title');
-    const desc = findSibling(event.target, 'ac__desc');
-    const titleEdit = findSibling(event.target, 'acbook__title__input');
-    const descEdit = findSibling(event.target, 'acbook__desc__input');
-
+    const index = event.target.dataset.turn;
     if (event.key === 'Enter') {
       await updateAccountBook({
         accountBookId: event.target.dataset.acbookid,
-        name: titleEdit.value,
-        description: descEdit.value,
+        name: titleEditRef[index].current.value,
+        description: descEditRef[index].current.value,
       });
 
       const updatedAcBooks = datas.map(item => {
         if (item._id === event.target.dataset.acbookid) {
           item = {
             ...item,
-            name: titleEdit.value,
-            description: descEdit.value,
+            name: titleEditRef[index].current.value,
+            description: descEditRef[index].current.value,
           };
         }
         return item;
       });
-
-      console.log(updatedAcBooks);
+      titleRef[index].current.classList.toggle('hidden');
+      descRef[index].current.classList.toggle('hidden');
+      titleEditRef[index].current.classList.toggle('hidden');
+      descEditRef[index].current.classList.toggle('hidden');
       setDatas(() => updatedAcBooks);
-      title.classList.toggle('hidden');
-      desc.classList.toggle('hidden');
-      titleEdit.classList.toggle('hidden');
-      descEdit.classList.toggle('hidden');
     }
   };
 
@@ -103,27 +104,42 @@ export const AccountBookList = ({ datas, setDatas }) => {
           onClick={linkToDetail}
           style={{ animationDelay: `${index * 0.08}s` }}
         >
-          <div className="ac__title link" data-acbookid={data._id}>
+          <div
+            className="ac__title link"
+            data-acbookid={data._id}
+            data-turn={index}
+            ref={titleRef[index]}
+          >
             {data.name}
           </div>
-          <div className="ac__desc link" data-acbookid={data._id}>
+          <div
+            className="ac__desc link"
+            data-acbookid={data._id}
+            data-turn={index}
+            ref={descRef[index]}
+          >
             {data.description}
           </div>
 
           <input
             className="acbook__title__input hidden"
             data-acbookid={data._id}
+            data-turn={index}
             onKeyPress={onEnterEditForm}
+            ref={titleEditRef[index]}
           />
           <textarea
             className="acbook__desc__input hidden"
             data-acbookid={data._id}
+            data-turn={index}
             onKeyPress={onEnterEditForm}
+            ref={descEditRef[index]}
           />
 
           <i
             className="fas fa-edit"
             data-id={data._id}
+            data-turn={index}
             onClick={onClickModify}
           />
           <i

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -58,6 +58,7 @@ export const AccountBookList = ({ datas, setDatas }) => {
             {data.description}
           </div>
 
+          <i className="fas fa-edit" data-id={data._id} />
           <i
             className="fas fa-trash-alt"
             data-id={data._id}

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -58,10 +58,11 @@ export const AccountBookList = ({ datas, setDatas }) => {
             name: titleEdit.value,
             description: descEdit.value,
           };
-          return item;
         }
+        return item;
       });
 
+      console.log(updatedAcBooks);
       setDatas(() => updatedAcBooks);
       title.classList.toggle('hidden');
       desc.classList.toggle('hidden');

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, isValidElement } from 'react';
+import React, { useEffect } from 'react';
 
 import { useHistory } from 'react-router-dom';
 
 import {
   getAccountBookList,
+  updateAccountBook,
   deleteAccountBook,
 } from '../../../api/accoun-book-list';
+
+import { findSibling } from '../../../util/findSibling';
 import './accountBookList.scss';
 
 export const AccountBookList = ({ datas, setDatas }) => {
@@ -19,8 +22,56 @@ export const AccountBookList = ({ datas, setDatas }) => {
     setDatas(accountBooks.data);
   };
 
+  const onClickModify = event => {
+    const title = findSibling(event.target, 'ac__title');
+    const desc = findSibling(event.target, 'ac__desc');
+    const titleEdit = findSibling(event.target, 'acbook__title__input');
+    const descEdit = findSibling(event.target, 'acbook__desc__input');
+
+    titleEdit.value = title.textContent;
+    descEdit.value = desc.textContent;
+
+    title.classList.toggle('hidden');
+    desc.classList.toggle('hidden');
+    titleEdit.classList.toggle('hidden');
+    descEdit.classList.toggle('hidden');
+    titleEdit.focus();
+  };
+
+  const onEnterEditForm = async event => {
+    const title = findSibling(event.target, 'ac__title');
+    const desc = findSibling(event.target, 'ac__desc');
+    const titleEdit = findSibling(event.target, 'acbook__title__input');
+    const descEdit = findSibling(event.target, 'acbook__desc__input');
+
+    if (event.key === 'Enter') {
+      await updateAccountBook({
+        accountBookId: event.target.dataset.acbookid,
+        name: titleEdit.value,
+        description: descEdit.value,
+      });
+
+      const updatedAcBooks = datas.map(item => {
+        if (item._id === event.target.dataset.acbookid) {
+          item = {
+            ...item,
+            name: titleEdit.value,
+            description: descEdit.value,
+          };
+          return item;
+        }
+      });
+
+      setDatas(() => updatedAcBooks);
+      title.classList.toggle('hidden');
+      desc.classList.toggle('hidden');
+      titleEdit.classList.toggle('hidden');
+      descEdit.classList.toggle('hidden');
+    }
+  };
+
   const linkToDetail = async event => {
-    if (!event.target.classList.contains('fa-trash-alt')) {
+    if (event.target.className === 'acbook') {
       history.push({
         pathname: '/calendar',
         state: {
@@ -58,7 +109,22 @@ export const AccountBookList = ({ datas, setDatas }) => {
             {data.description}
           </div>
 
-          <i className="fas fa-edit" data-id={data._id} />
+          <input
+            className="acbook__title__input hidden"
+            data-acbookid={data._id}
+            onKeyPress={onEnterEditForm}
+          />
+          <textarea
+            className="acbook__desc__input hidden"
+            data-acbookid={data._id}
+            onKeyPress={onEnterEditForm}
+          />
+
+          <i
+            className="fas fa-edit"
+            data-id={data._id}
+            onClick={onClickModify}
+          />
           <i
             className="fas fa-trash-alt"
             data-id={data._id}

--- a/FE/src/components/AccountBook/AccountBookList/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookList/index.tsx
@@ -71,7 +71,7 @@ export const AccountBookList = ({ datas, setDatas }) => {
   };
 
   const linkToDetail = async event => {
-    if (event.target.className === 'acbook') {
+    if (event.target.classList.contains('link')) {
       history.push({
         pathname: '/calendar',
         state: {
@@ -97,15 +97,15 @@ export const AccountBookList = ({ datas, setDatas }) => {
       {datas.map((data, index) => (
         <div
           key={data._id}
-          className="acbook"
+          className="acbook link"
           data-acbookid={data._id}
           onClick={linkToDetail}
           style={{ animationDelay: `${index * 0.08}s` }}
         >
-          <div className="ac__title" data-acbookid={data._id}>
+          <div className="ac__title link" data-acbookid={data._id}>
             {data.name}
           </div>
-          <div className="ac__desc" data-acbookid={data._id}>
+          <div className="ac__desc link" data-acbookid={data._id}>
             {data.description}
           </div>
 

--- a/FE/src/components/Calendar/CalendarBody/calendarBody.scss
+++ b/FE/src/components/Calendar/CalendarBody/calendarBody.scss
@@ -10,6 +10,7 @@ td {
   .income__info {
     font-size: 0.8em;
     color: $income-color;
+    // padding-top: 1em;
   }
   .spending__info {
     font-size: 0.8em;
@@ -21,6 +22,7 @@ td {
   background-color: #222;
   border-radius: 6px;
   position: relative;
+
   cursor: pointer;
   &:hover {
     animation: dateHover 1s;

--- a/FE/src/components/Calendar/DetailModal/detailModal.scss
+++ b/FE/src/components/Calendar/DetailModal/detailModal.scss
@@ -30,10 +30,14 @@
     border: 1px solid #979797;
     color: #979797;
 
-    animation: detailFormShow 1s;
+    animation: detailFormShow 1s ease;
     @keyframes detailFormShow {
       from {
+        opacity: 0;
         transform: translateY(500px);
+      }
+      to {
+        opacity: 1;
       }
     }
 
@@ -62,12 +66,15 @@
         background-color: #333;
         color: #979797;
         position: relative;
-        animation: specificDataShow 1s;
+        animation: specificDataShow 1s backwards;
 
         @keyframes specificDataShow {
           from {
             opacity: 0;
             transform: translateX(-100px);
+          }
+          to {
+            opacity: 1;
           }
         }
         .specific__content {

--- a/FE/src/components/Common/MenuBar/index.tsx
+++ b/FE/src/components/Common/MenuBar/index.tsx
@@ -16,10 +16,6 @@ const MenuBar = ({ id, setModal, pageType }) => {
   const btnPrevRef = useRef();
   const calMonRef = useRef();
   const calYearRef = useRef();
-  const transactionIconRef = useRef();
-  const calIconRef = useRef();
-  const chartIconRef = useRef();
-  const backIconRef = useRef();
 
   const setYearMonth = useCallback((year, month) => {
     const yy = year;
@@ -62,7 +58,6 @@ const MenuBar = ({ id, setModal, pageType }) => {
     <header className="menubar__header">
       <div className="menubar__buttons" ref={allBtnRef}>
         <div
-          ref={backIconRef}
           className={pageType === '/' ? 'back__navBtn checked' : 'back__navBtn'}
           data-type="/"
           onClick={onClickIcon}
@@ -71,7 +66,6 @@ const MenuBar = ({ id, setModal, pageType }) => {
           <span data-type="/">List</span>
         </div>
         <div
-          ref={transactionIconRef}
           className={
             pageType === 'transaction'
               ? 'menubar__navBtn checked'
@@ -83,7 +77,6 @@ const MenuBar = ({ id, setModal, pageType }) => {
           <i data-type="transaction" className="fas fa-history" />
         </div>
         <div
-          ref={calIconRef}
           className={
             pageType === 'calendar'
               ? 'menubar__navBtn checked'
@@ -95,7 +88,6 @@ const MenuBar = ({ id, setModal, pageType }) => {
           <i data-type="calendar" className="far fa-calendar-alt" />
         </div>
         <div
-          ref={chartIconRef}
           className={
             pageType === 'chart' ? 'menubar__navBtn checked' : 'menubar__navBtn'
           }
@@ -106,6 +98,19 @@ const MenuBar = ({ id, setModal, pageType }) => {
         </div>
         <div className="menubar__navBtn" onClick={onClickPayment}>
           <i className="fas fa-credit-card" />
+        </div>
+
+        <div
+          className={
+            pageType === '/setting'
+              ? 'setting__navBtn checked'
+              : 'setting__navBtn'
+          }
+          data-type="setting"
+          onClick={onClickIcon}
+        >
+          <span data-type="/setting">Setting</span>
+          <i data-type="/setting" className="fas fa-arrow-right" />
         </div>
       </div>
 

--- a/FE/src/components/Common/MenuBar/menubar.scss
+++ b/FE/src/components/Common/MenuBar/menubar.scss
@@ -33,6 +33,26 @@
       text-shadow: $selectedTextShadow;
       color: white;
     }
+    .setting__navBtn {
+      @include buttonDefaultSetting;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      right: 1.5em;
+      text-align: center;
+      line-height: 1.5em;
+      width: 3.5em;
+      height: 1.5em;
+      background-color: transparent;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 0.5em;
+      font-size: 1.5em;
+      box-shadow: $selectedBoxShadow;
+      text-shadow: $selectedTextShadow;
+      color: white;
+    }
     .menubar__navBtn {
       @include buttonDefaultSetting;
       text-align: center;

--- a/FE/src/components/DateChart/LineChart/index.tsx
+++ b/FE/src/components/DateChart/LineChart/index.tsx
@@ -57,6 +57,10 @@ export default function LineChart() {
         legend: {
           display: true,
           position: 'right',
+          labels: {
+            fontSize: 12,
+            fontColor: 'white',
+          },
         },
         maintainAspectRatio: false,
         scales: {
@@ -64,6 +68,9 @@ export default function LineChart() {
             {
               ticks: {
                 min: 0,
+              },
+              gridLines: {
+                color: 'rgba(255,255,255,0.2)',
               },
             },
           ],

--- a/FE/src/components/DateChart/LineChart/index.tsx
+++ b/FE/src/components/DateChart/LineChart/index.tsx
@@ -22,7 +22,8 @@ export default function LineChart() {
     labels: days,
     datasets: [
       {
-        label: 'spending',
+        label: 'Spending',
+        labelColor: 'red',
         fill: false,
         lineTension: 0.5,
         borderColor: '#ee4337',
@@ -35,7 +36,7 @@ export default function LineChart() {
         pointHoverBorderColor: 'rgba(220,220,220,1)',
       },
       {
-        label: 'income',
+        label: 'Income',
         fill: false,
         lineTension: 0.5,
         borderColor: '#54aafc',

--- a/FE/src/components/DateChart/LineChart/index.tsx
+++ b/FE/src/components/DateChart/LineChart/index.tsx
@@ -1,5 +1,73 @@
 import React from 'react';
+import { Line } from 'react-chartjs-2';
 
-export default function LineChart(props) {
-  return <h1>line chart</h1>;
+import { useRootData } from '../../../store/DateInfo/dateInfoHook';
+import { useTransactionData } from '../../../store/AccountBook/accountBookInfoHook';
+
+export default function LineChart() {
+  const DateInfo = useRootData(store => store.nowCalendarInfo);
+  const YearMonthTransactions = useTransactionData(store =>
+    store.getTransactionsForCalendar(DateInfo.year, DateInfo.month + 1),
+  );
+
+  const days = Object.keys(YearMonthTransactions);
+  const spendingDatas = days.map(day => {
+    return YearMonthTransactions[day].spending;
+  });
+  const incomeDatas = days.map(day => {
+    return YearMonthTransactions[day].income;
+  });
+
+  const state = {
+    labels: days,
+    datasets: [
+      {
+        label: 'spending',
+        fill: false,
+        lineTension: 0.5,
+        borderColor: '#ee4337',
+        borderWidth: 2,
+        borderCapStyle: 'round',
+        data: spendingDatas,
+        pointBackgroundColor: '#ee4337',
+        pointBorderColor: '#ee4337',
+        pointHoverRadius: 7,
+        pointHoverBorderColor: 'rgba(220,220,220,1)',
+      },
+      {
+        label: 'income',
+        fill: false,
+        lineTension: 0.5,
+        borderColor: '#54aafc',
+        borderWidth: 2,
+        data: incomeDatas,
+        pointBackgroundColor: '#54aafc',
+        pointBorderColor: '#54aafc',
+        pointHoverRadius: 7,
+        pointHoverBorderColor: 'rgba(220,220,220,1)',
+      },
+    ],
+  };
+
+  return (
+    <Line
+      data={state}
+      options={{
+        legend: {
+          display: true,
+          position: 'right',
+        },
+        maintainAspectRatio: false,
+        scales: {
+          yAxes: [
+            {
+              ticks: {
+                min: 0,
+              },
+            },
+          ],
+        },
+      }}
+    />
+  );
 }

--- a/FE/src/components/PaymentMethod/AddTemplate/index.tsx
+++ b/FE/src/components/PaymentMethod/AddTemplate/index.tsx
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect, useContext, useState } from 'react';
 import { useTransactionData } from '../../../store/AccountBook/accountBookInfoHook';
-import { paymentContext } from '../../../store/PaymentMethod/paymentMethodContext';
 import { useRootData } from '../../../store/PaymentMethod/paymentMethodHook';
 
+import { createPaymentMethod } from '../../../api/payment-method';
 import './addForm.scss';
 
 interface Card {
@@ -14,22 +14,27 @@ export default function AddTemplate({
 }: Card): React.ReactElement {
   const [methodNick, setMethodNick] = useState('');
   const methodInput = useRef();
-  const store = useContext(paymentContext);
+
   const addTemplateData = useRootData(store => store.addTemplateData);
-  const addPaymentMethod = useTransactionData(store => store.addPaymentMethod);
   const updateAddTemplate = useRootData(store => store.updateAddTemplate);
+
+  const addPaymentMethod = useTransactionData(store => store.addPaymentMethod);
+  const accountBookId = useTransactionData(store => store.accountBook._id);
 
   const onChangeNick = (event: React.ChangeEvent<HTMLInputElement>) => {
     setMethodNick(event.target.value);
   };
 
-  const onAddCard = event => {
+  const onAddCard = async event => {
     if (event.key === 'Enter') {
-      addPaymentMethod({
+      const res = await createPaymentMethod({
+        accountBookId,
         name: addTemplateData.name,
         desc: `${methodNick}`,
         color: addTemplateData.color,
       });
+
+      addPaymentMethod(res.data);
 
       setAddFormModal(() => false);
       updateAddTemplate({ name: '', color: '' });

--- a/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
+++ b/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
@@ -28,11 +28,6 @@
     border-radius: 6px;
     padding: 1.5em;
 
-    .card__cancel {
-      position: absolute;
-      right: 1.5em;
-      top: 1em;
-    }
     .card__title {
       font-size: 2em;
       padding: 0.2em 0;
@@ -41,6 +36,28 @@
 
     .card__desc {
       font-size: 1.2em;
+    }
+
+    .fas.fa-trash-alt {
+      position: absolute;
+      right: 1.2em;
+      top: 1.5em;
+      font-size: 1.5em;
+
+      &:hover {
+        color: black;
+
+        animation: deleteBtn 1s forwards;
+
+        @keyframes deleteBtn {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      }
     }
 
     &:hover {

--- a/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
+++ b/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
@@ -36,12 +36,46 @@
 
     .card__desc {
       font-size: 1.2em;
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .desc__input {
+      width: 200px;
+      text-decoration: none;
+
+      &.hidden {
+        display: none;
+      }
+    }
+
+    .fas.fa-edit {
+      position: absolute;
+      right: 1em;
+      top: 1.5em;
+      font-size: 1.5em;
+
+      &:hover {
+        color: black;
+
+        animation: deleteBtn 1s forwards;
+
+        @keyframes deleteBtn {
+          from {
+            transform: rotate(0deg);
+          }
+          to {
+            transform: rotate(360deg);
+          }
+        }
+      }
     }
 
     .fas.fa-trash-alt {
       position: absolute;
       right: 1.2em;
-      top: 1.5em;
+      top: 3.5em;
       font-size: 1.5em;
 
       &:hover {

--- a/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
+++ b/FE/src/components/PaymentMethod/CardContainer/cardContainer.scss
@@ -13,6 +13,7 @@
   overflow-x: hidden;
   flex: 1;
   z-index: 2;
+  margin-top: 3em;
 
   .card__container__card {
     position: relative;

--- a/FE/src/components/PaymentMethod/CardContainer/index.tsx
+++ b/FE/src/components/PaymentMethod/CardContainer/index.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { v4 } from 'uuid';
 
 import { useTransactionData } from '../../../store/AccountBook/accountBookInfoHook';
-import { deletePaymentMethod } from '../../../api/payment-method';
+import {
+  updatePaymentMethod,
+  deletePaymentMethod,
+} from '../../../api/payment-method';
 import './cardContainer.scss';
 
 export default React.memo(function CardContainer(): React.ReactElement {
@@ -10,10 +12,44 @@ export default React.memo(function CardContainer(): React.ReactElement {
   const paymentMethods = useTransactionData(
     store => store.accountBook.payments,
   );
+  const updatePayment = useTransactionData(store => store.updatePaymentMethod);
   const deletePayment = useTransactionData(store => store.deletePaymentMethod);
 
+  const onClickModify = event => {
+    const editForm = event.target.previousSibling;
+    const content = editForm.previousSibling;
+
+    editForm.value = content.textContent;
+
+    editForm.classList.toggle('hidden');
+    content.classList.toggle('hidden');
+
+    editForm.focus();
+  };
+
+  const onEnterEditForm = async event => {
+    const content = event.target.previousSibling;
+
+    if (event.key === 'Enter') {
+      await updatePaymentMethod({
+        accountBookId,
+        paymentId: event.target.dataset.cardid,
+        name: event.target.dataset.name,
+        desc: event.target.value,
+        color: event.target.dataset.color,
+      });
+
+      updatePayment({
+        id: event.target.dataset.cardid,
+        desc: event.target.value,
+      });
+      event.target.classList.toggle('hidden');
+      content.classList.toggle('hidden');
+    }
+  };
+
   const onClickDelete = async event => {
-    const res = await deletePaymentMethod({
+    await deletePaymentMethod({
       accountBookId,
       paymentId: event.target.dataset.cardid,
     });
@@ -25,7 +61,7 @@ export default React.memo(function CardContainer(): React.ReactElement {
     <div className="card__container" data-overlay>
       {paymentMethods.map((card, i) => (
         <div
-          key={v4()}
+          key={card._id}
           className="card__container__card"
           style={{
             background: `${card.color}`,
@@ -34,6 +70,20 @@ export default React.memo(function CardContainer(): React.ReactElement {
         >
           <div className="card__title">{card.name}</div>
           <div className="card__desc">{card.desc}</div>
+
+          <input
+            className="desc__input hidden"
+            onKeyPress={onEnterEditForm}
+            data-cardid={card._id}
+            data-name={card.name}
+            data-color={card.color}
+          />
+
+          <i
+            className="fas fa-edit"
+            data-cardid={card._id}
+            onClick={onClickModify}
+          />
           <i
             className="fas fa-trash-alt"
             data-cardid={card._id}

--- a/FE/src/components/PaymentMethod/CardContainer/index.tsx
+++ b/FE/src/components/PaymentMethod/CardContainer/index.tsx
@@ -15,20 +15,29 @@ export default React.memo(function CardContainer(): React.ReactElement {
   const updatePayment = useTransactionData(store => store.updatePaymentMethod);
   const deletePayment = useTransactionData(store => store.deletePaymentMethod);
 
+  const contentRefArr = [];
+  const editFormRefArr = [];
+  paymentMethods.forEach(() => {
+    contentRefArr.push(React.createRef());
+    editFormRefArr.push(React.createRef());
+  });
+
   const onClickModify = event => {
-    const editForm = event.target.previousSibling;
-    const content = editForm.previousSibling;
+    const index = event.target.dataset.turn;
+    const editForm = editFormRefArr[index];
+    const content = contentRefArr[index];
 
-    editForm.value = content.textContent;
+    editForm.current.value = content.current.textContent;
 
-    editForm.classList.toggle('hidden');
-    content.classList.toggle('hidden');
+    editForm.current.classList.toggle('hidden');
+    content.current.classList.toggle('hidden');
 
-    editForm.focus();
+    editForm.current.focus();
   };
 
   const onEnterEditForm = async event => {
-    const content = event.target.previousSibling;
+    const index = event.target.dataset.turn;
+    const content = contentRefArr[index];
 
     if (event.key === 'Enter') {
       await updatePaymentMethod({
@@ -39,12 +48,12 @@ export default React.memo(function CardContainer(): React.ReactElement {
         color: event.target.dataset.color,
       });
 
+      event.target.classList.toggle('hidden');
+      content.current.classList.toggle('hidden');
       updatePayment({
         id: event.target.dataset.cardid,
         desc: event.target.value,
       });
-      event.target.classList.toggle('hidden');
-      content.classList.toggle('hidden');
     }
   };
 
@@ -69,7 +78,9 @@ export default React.memo(function CardContainer(): React.ReactElement {
           }}
         >
           <div className="card__title">{card.name}</div>
-          <div className="card__desc">{card.desc}</div>
+          <div className="card__desc" ref={contentRefArr[i]}>
+            {card.desc}
+          </div>
 
           <input
             className="desc__input hidden"
@@ -77,12 +88,15 @@ export default React.memo(function CardContainer(): React.ReactElement {
             data-cardid={card._id}
             data-name={card.name}
             data-color={card.color}
+            data-turn={i}
+            ref={editFormRefArr[i]}
           />
 
           <i
             className="fas fa-edit"
             data-cardid={card._id}
             onClick={onClickModify}
+            data-turn={i}
           />
           <i
             className="fas fa-trash-alt"

--- a/FE/src/components/PaymentMethod/CardContainer/index.tsx
+++ b/FE/src/components/PaymentMethod/CardContainer/index.tsx
@@ -2,13 +2,24 @@ import React from 'react';
 import { v4 } from 'uuid';
 
 import { useTransactionData } from '../../../store/AccountBook/accountBookInfoHook';
-
+import { deletePaymentMethod } from '../../../api/payment-method';
 import './cardContainer.scss';
 
 export default React.memo(function CardContainer(): React.ReactElement {
+  const accountBookId = useTransactionData(store => store.accountBook._id);
   const paymentMethods = useTransactionData(
     store => store.accountBook.payments,
   );
+  const deletePayment = useTransactionData(store => store.deletePaymentMethod);
+
+  const onClickDelete = async event => {
+    const res = await deletePaymentMethod({
+      accountBookId,
+      paymentId: event.target.dataset.cardid,
+    });
+
+    deletePayment(event.target.dataset.cardid);
+  };
 
   return (
     <div className="card__container" data-overlay>
@@ -21,9 +32,13 @@ export default React.memo(function CardContainer(): React.ReactElement {
             animationDelay: `${i * 0.08}s`,
           }}
         >
-          <div className="card__cancel">X</div>
           <div className="card__title">{card.name}</div>
           <div className="card__desc">{card.desc}</div>
+          <i
+            className="fas fa-trash-alt"
+            data-cardid={card._id}
+            onClick={onClickDelete}
+          />
         </div>
       ))}
     </div>

--- a/FE/src/components/PaymentMethod/Modal/index.tsx
+++ b/FE/src/components/PaymentMethod/Modal/index.tsx
@@ -23,7 +23,7 @@ export default function PaymentModal({
   return (
     <>
       <div className="modal__wrapper" data-overlay onClick={onClickOverlay}>
-        <span className="title">Payment Method</span>
+        <span className="payment__title">Payment Method</span>
         <button type="button" onClick={onClickNew} className="new__button">
           Add
         </button>

--- a/FE/src/components/PaymentMethod/Modal/modal.scss
+++ b/FE/src/components/PaymentMethod/Modal/modal.scss
@@ -6,12 +6,12 @@
   width: 100%;
   height: 100%;
   background-color: $modal-background;
+  padding: 7em;
   z-index: 2;
-  .title {
+  .payment__title {
     display: inline-block;
     color: $white;
-    padding: 1em 2em;
-    font-size: 4rem;
+    font-size: 5em;
     width: 100%;
     text-shadow: $selectedTextShadow;
   }
@@ -21,8 +21,8 @@
     border: 1px solid $white;
     color: $white;
     position: absolute;
-    top: 10em;
-    left: 19em;
+    top: 15em;
+    left: 23em;
     width: 8em;
     height: 50px;
     background-color: $modal-button-background;

--- a/FE/src/components/SettingBar/index.tsx
+++ b/FE/src/components/SettingBar/index.tsx
@@ -1,7 +1,44 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 import './settingBar.scss';
 
 export default function SettingBar(props) {
-  return <div className="setting__bar__container">hello</div>;
+  const history = useHistory();
+  const id = history.location.state;
+
+  const onClickBackBtn = event => {
+    history.push({
+      pathname: event.target.dataset.type,
+      state: {
+        id,
+      },
+    });
+  };
+  return (
+    <header className="settingbar__header">
+      <div className="settingbar__buttons">
+        <div
+          data-type="/calendar"
+          className="settingbar__back__navBtn checked"
+          onClick={onClickBackBtn}
+        >
+          <i data-type="/calendar" className="fas fa-arrow-left" />
+          <span data-type="/calendar">Account Book</span>
+        </div>
+        <div className="settingbar__navBtn checked">
+          <i className="fas fa-users" />
+        </div>
+        <div className="settingbar__navBtn checked">
+          <i className="far fa-calendar-alt" />
+        </div>
+        <div className="settingbar__navBtn checked">
+          <i className="fas fa-boxes" />
+        </div>
+        <div className="settingbar__navBtn checked">
+          <i className="fas fa-file-csv" />
+        </div>
+      </div>
+    </header>
+  );
 }

--- a/FE/src/components/SettingBar/index.tsx
+++ b/FE/src/components/SettingBar/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import './settingBar.scss';
+
+export default function SettingBar(props) {
+  return <div className="setting__bar__container">hello</div>;
+}

--- a/FE/src/components/SettingBar/index.tsx
+++ b/FE/src/components/SettingBar/index.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 
 import './settingBar.scss';
 
-export default function SettingBar(props) {
+export default function SettingBar({ settingType, setSettingType }) {
   const history = useHistory();
   const id = history.location.state;
 

--- a/FE/src/components/SettingBar/index.tsx
+++ b/FE/src/components/SettingBar/index.tsx
@@ -5,16 +5,21 @@ import './settingBar.scss';
 
 export default function SettingBar({ settingType, setSettingType }) {
   const history = useHistory();
-  const id = history.location.state;
+  const accountBookId = history.location.state.id;
 
   const onClickBackBtn = event => {
     history.push({
       pathname: event.target.dataset.type,
       state: {
-        id,
+        id: accountBookId,
       },
     });
   };
+
+  const onClickIcon = event => {
+    setSettingType(event.target.dataset.type);
+  };
+
   return (
     <header className="settingbar__header">
       <div className="settingbar__buttons">
@@ -26,17 +31,49 @@ export default function SettingBar({ settingType, setSettingType }) {
           <i data-type="/calendar" className="fas fa-arrow-left" />
           <span data-type="/calendar">Account Book</span>
         </div>
-        <div className="settingbar__navBtn checked">
-          <i className="fas fa-users" />
+        <div
+          className={
+            settingType === 'user'
+              ? 'settingbar__navBtn checked'
+              : 'settingbar__navBtn'
+          }
+          onClick={onClickIcon}
+          data-type="user"
+        >
+          <i data-type="user" className="fas fa-users" />
         </div>
-        <div className="settingbar__navBtn checked">
-          <i className="far fa-calendar-alt" />
+        <div
+          className={
+            settingType === 'calendar'
+              ? 'settingbar__navBtn checked'
+              : 'settingbar__navBtn'
+          }
+          onClick={onClickIcon}
+          data-type="calendar"
+        >
+          <i data-type="calendar" className="far fa-calendar-alt" />
         </div>
-        <div className="settingbar__navBtn checked">
-          <i className="fas fa-boxes" />
+        <div
+          className={
+            settingType === 'category'
+              ? 'settingbar__navBtn checked'
+              : 'settingbar__navBtn'
+          }
+          onClick={onClickIcon}
+          data-type="category"
+        >
+          <i data-type="category" className="fas fa-boxes" />
         </div>
-        <div className="settingbar__navBtn checked">
-          <i className="fas fa-file-csv" />
+        <div
+          className={
+            settingType === 'csv'
+              ? 'settingbar__navBtn checked'
+              : 'settingbar__navBtn'
+          }
+          onClick={onClickIcon}
+          data-type="csv"
+        >
+          <i data-type="csv" className="fas fa-file-csv" />
         </div>
       </div>
     </header>

--- a/FE/src/components/SettingBar/settingBar.scss
+++ b/FE/src/components/SettingBar/settingBar.scss
@@ -7,6 +7,7 @@
   height: 20%;
   padding: 2.5em 0;
   z-index: 2;
+  overflow-x: hidden;
   .settingbar__buttons {
     display: flex;
     justify-content: center;

--- a/FE/src/components/SettingBar/settingBar.scss
+++ b/FE/src/components/SettingBar/settingBar.scss
@@ -1,3 +1,108 @@
-.setting__bar__container {
-  color: white;
+@use '../../styles/values' as *;
+@use '../../styles/mixins' as *;
+
+.settingbar__header {
+  background-color: $black;
+  width: 100%;
+  height: 20%;
+  padding: 2.5em 0;
+  z-index: 2;
+  .settingbar__buttons {
+    display: flex;
+    justify-content: center;
+    gap: 3em;
+    position: relative;
+
+    .settingbar__back__navBtn {
+      @include buttonDefaultSetting;
+      position: absolute;
+      top: 50%;
+      transform: translateY(-50%);
+      left: 0.5em;
+      text-align: center;
+      line-height: 1.5em;
+      width: 10em;
+      height: 1.5em;
+      background-color: transparent;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 0.5em;
+      font-size: 1.5em;
+      box-shadow: $selectedBoxShadow;
+      text-shadow: $selectedTextShadow;
+      color: white;
+    }
+
+    .settingbar__navBtn {
+      @include buttonDefaultSetting;
+      text-align: center;
+      line-height: 2.5em;
+      width: 2.5em;
+      height: 2.5em;
+      background-color: transparent;
+      color: rgba(255, 255, 255, 0.6);
+      font-size: 1.5em;
+      // box-shadow: $noSelectedBoxShadow;
+      &:hover {
+        box-shadow: $selectedBoxShadow;
+        text-shadow: $selectedTextShadow;
+        color: white;
+      }
+      &.checked {
+        box-shadow: $selectedBoxShadow;
+        text-shadow: $selectedTextShadow;
+        color: white;
+      }
+    }
+  }
+
+  .settingbar__ctrBox {
+    margin-top: 1.5em;
+    font-size: 20px;
+    display: flex;
+    justify-content: center;
+    gap: 2em;
+    font-weight: 900;
+    color: white;
+    text-shadow: $selectedTextShadow;
+
+    .btn-cal {
+      @include buttonDefaultSetting;
+      position: relative;
+      float: left;
+      width: 25px;
+      height: 25px;
+      margin-top: 5px;
+      font-size: 16px;
+      background: none;
+      font-weight: 900;
+      color: white;
+      text-shadow: $selectedTextShadow;
+    }
+    .btn-cal:after {
+      content: '<';
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      line-height: 25px;
+      font-weight: bold;
+      font-size: 20px;
+    }
+    .btn-cal.next {
+      float: right;
+    }
+    .btn-cal.next:after {
+      content: '>';
+    }
+
+    .year-month {
+      width: 200px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+  }
 }

--- a/FE/src/components/SettingBar/settingBar.scss
+++ b/FE/src/components/SettingBar/settingBar.scss
@@ -1,0 +1,3 @@
+.setting__bar__container {
+  color: white;
+}

--- a/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
+++ b/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
@@ -1,0 +1,3 @@
+.csv__setting__container {
+  color: white;
+}

--- a/FE/src/components/SettingContent/CSVSetting/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import './csvSetting.scss';
+
+export default function CSVSetting(props) {
+  return <div className="csv__setting__container">csv</div>;
+}

--- a/FE/src/components/SettingContent/CalendarSetting/calendarSetting.scss
+++ b/FE/src/components/SettingContent/CalendarSetting/calendarSetting.scss
@@ -1,0 +1,3 @@
+.calndar__setting__container {
+  color: white;
+}

--- a/FE/src/components/SettingContent/CalendarSetting/index.tsx
+++ b/FE/src/components/SettingContent/CalendarSetting/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import './calendarSetting.scss';
+
+export default function CalendarSetting(props) {
+  return <div className="calndar__setting__container">calendar</div>;
+}

--- a/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
+++ b/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
@@ -1,0 +1,3 @@
+.category__setting__container {
+  color: white;
+}

--- a/FE/src/components/SettingContent/CategorySetting/index.tsx
+++ b/FE/src/components/SettingContent/CategorySetting/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import './categorySetting.scss';
+
+export default function CategorySetting(props) {
+  return <div className="category__setting__container">category</div>;
+}

--- a/FE/src/components/SettingContent/UserSetting/index.tsx
+++ b/FE/src/components/SettingContent/UserSetting/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import './userSetting.scss';
+
+export default function UserSetting(props) {
+  return <div className="user__setting__container">user</div>;
+}

--- a/FE/src/components/SettingContent/UserSetting/userSetting.scss
+++ b/FE/src/components/SettingContent/UserSetting/userSetting.scss
@@ -1,0 +1,3 @@
+.user__setting__container {
+  color: white;
+}

--- a/FE/src/pages/AccountBook/AccountBookListPage.scss
+++ b/FE/src/pages/AccountBook/AccountBookListPage.scss
@@ -1,12 +1,9 @@
 .acbook__list__container {
-  position: relative;
+  position: absolute;
   width: 100%;
   height: 100%;
   display: flex;
-  // padding: 5em 3em;
   background-color: rgba(0, 0, 0, 0.9);
-  overflow-x: hidden;
-
   animation: showPage 1s ease;
 
   @keyframes showPage {

--- a/FE/src/pages/AccountBook/AccountBookListPage.scss
+++ b/FE/src/pages/AccountBook/AccountBookListPage.scss
@@ -11,7 +11,6 @@
 
   @keyframes showPage {
     from {
-      opacity: 0;
       transform: translateX(-100%);
     }
   }

--- a/FE/src/pages/Chart/chart.scss
+++ b/FE/src/pages/Chart/chart.scss
@@ -5,8 +5,13 @@
   flex-direction: column;
   position: relative;
 
-  .date__charts,
   .category__charts {
+    width: 100%;
+    height: 100%;
+  }
+
+  .date__charts {
+    padding: 2em 10em;
     width: 100%;
     height: 100%;
   }

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import './settingPage.scss';
+
+export default function SettingPage() {
+  return <div className="setting__page__wrapper">hello</div>;
+}

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -6,8 +6,8 @@ import './settingPage.scss';
 
 export default function SettingPage() {
   return (
-    <>
+    <div className="setting__page__wrapper">
       <SettingBar />
-    </>
+    </div>
   );
 }

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import SettingBar from '../../components/SettingBar';
 
 import './settingPage.scss';
 
 export default function SettingPage() {
+  const [settingType, setSettingType] = useState('users');
   return (
     <div className="setting__page__wrapper">
-      <SettingBar />
+      <SettingBar settingType={settingType} setSettingType={setSettingType} />
     </div>
   );
 }

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -2,13 +2,22 @@ import React, { useState } from 'react';
 
 import SettingBar from '../../components/SettingBar';
 
+import UserSetting from '../../components/SettingContent/UserSetting';
+import CalendarSetting from '../../components/SettingContent/CalendarSetting';
+import CategorySetting from '../../components/SettingContent/CategorySetting';
+import CSVSetting from '../../components/SettingContent/CSVSetting';
+
 import './settingPage.scss';
 
 export default function SettingPage() {
-  const [settingType, setSettingType] = useState('users');
+  const [settingType, setSettingType] = useState('user');
   return (
     <div className="setting__page__wrapper">
       <SettingBar settingType={settingType} setSettingType={setSettingType} />
+      {settingType === 'user' && <UserSetting />}
+      {settingType === 'calendar' && <CalendarSetting />}
+      {settingType === 'category' && <CategorySetting />}
+      {settingType === 'csv' && <CSVSetting />}
     </div>
   );
 }

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 
+import SettingBar from '../../components/SettingBar';
+
 import './settingPage.scss';
 
 export default function SettingPage() {
-  return <div className="setting__page__wrapper">hello</div>;
+  return (
+    <>
+      <SettingBar />
+    </>
+  );
 }

--- a/FE/src/pages/SettingPage/settingPage.scss
+++ b/FE/src/pages/SettingPage/settingPage.scss
@@ -1,9 +1,13 @@
 .setting__page__wrapper {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
   animation: showSettingPage 1s ease;
+  color: white;
+
   @keyframes showSettingPage {
     from {
-      opacity: 0;
-
       transform: translateX(100%);
     }
   }

--- a/FE/src/pages/SettingPage/settingPage.scss
+++ b/FE/src/pages/SettingPage/settingPage.scss
@@ -1,3 +1,10 @@
 .setting__page__wrapper {
-  color: white;
+  animation: showSettingPage 1s ease;
+  @keyframes showSettingPage {
+    from {
+      opacity: 0;
+
+      transform: translateX(100%);
+    }
+  }
 }

--- a/FE/src/pages/SettingPage/settingPage.scss
+++ b/FE/src/pages/SettingPage/settingPage.scss
@@ -3,6 +3,7 @@
   width: 100%;
   height: 100%;
   display: flex;
+  flex-direction: column;
   animation: showSettingPage 1s ease;
   color: white;
 

--- a/FE/src/pages/SettingPage/settingPage.scss
+++ b/FE/src/pages/SettingPage/settingPage.scss
@@ -1,0 +1,3 @@
+.setting__page__wrapper {
+  color: white;
+}

--- a/FE/src/service/fetch.ts
+++ b/FE/src/service/fetch.ts
@@ -26,7 +26,7 @@ export const postFetch = async (query, body) => {
 
 export const updateFetch = async (query, body) => {
   const response = await fetch(`${query}`, {
-    method: 'PUT',
+    method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${window.localStorage.getItem('token')}`,

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -16,7 +16,7 @@ export const createStore = () => {
 
     async setAccountBook(id) {
       const accountBook = await getTargetAccountBook(id);
-
+      accountBook.data.payments.reverse();
       this.accountBook = accountBook.data;
     },
 

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -24,6 +24,12 @@ export const createStore = () => {
       this.accountBook.payments = [data, ...this.accountBook.payments];
     },
 
+    deletePaymentMethod(id) {
+      this.accountBook.payments = this.accountBook.payments.filter(
+        payment => payment._id !== id,
+      );
+    },
+
     filterTransaction(
       category: string,
       year: number,

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -8,7 +8,7 @@ export const createStore = () => {
       description: null,
       categories: [],
       payments: [],
-      user: [],
+      users: [],
       transactions: [],
     },
 

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -69,9 +69,6 @@ export const createStore = () => {
         return acc;
       }, {});
 
-      console.log(categoryFiltered);
-      console.log(transactionsGroupByDate);
-
       this.filteredTransactions = transactionsGroupByDate;
     },
 

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -25,7 +25,6 @@ export const createStore = () => {
     },
 
     updatePaymentMethod(data: { id: string; desc: string }) {
-      console.log(data.desc);
       const updatedPayments = [...this.accountBook.payments];
       updatedPayments = updatedPayments.map(item => {
         if (item._id === data.id) {
@@ -33,7 +32,6 @@ export const createStore = () => {
         }
         return item;
       });
-      console.log(updatedPayments[0].desc);
       this.accountBook.payments = updatedPayments;
     },
 

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -24,6 +24,19 @@ export const createStore = () => {
       this.accountBook.payments = [data, ...this.accountBook.payments];
     },
 
+    updatePaymentMethod(data: { id: string; desc: string }) {
+      console.log(data.desc);
+      const updatedPayments = [...this.accountBook.payments];
+      updatedPayments = updatedPayments.map(item => {
+        if (item._id === data.id) {
+          item = { ...item, desc: data.desc };
+        }
+        return item;
+      });
+      console.log(updatedPayments[0].desc);
+      this.accountBook.payments = updatedPayments;
+    },
+
     deletePaymentMethod(id) {
       this.accountBook.payments = this.accountBook.payments.filter(
         payment => payment._id !== id,

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -6,7 +6,7 @@ export const createStore = () => {
       _id: null,
       name: null,
       description: null,
-      category: [],
+      categories: [],
       payments: [],
       user: [],
       transactions: [],

--- a/FE/src/util/findSibling.ts
+++ b/FE/src/util/findSibling.ts
@@ -1,0 +1,9 @@
+export const findSibling = (target, className) => {
+  const siblings = target.parentNode.childNodes;
+
+  for (let i = 0; i < siblings.length; i++) {
+    if (siblings[i].classList.contains(className)) {
+      return siblings[i];
+    }
+  }
+};


### PR DESCRIPTION
### 📕 Issue Number

Closes #95 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] setting page틀을 생성하였습니다.
- detail page와 같은 디자인 형태로 의견을 맞추었기 때문에 비슷한 레이아웃으로 구성하였습니다.

- [x] 공통 컴포넌트 사용 X
- Detail 페이지의 Header와 완전히 유사하지만 , Detail 페이지에서 사용되는 header의 경우 실제로 주소를 바꿔버리는 라우팅 형태의 
클릭이벤트가 사용되고 있습니다.
- setting page에서는 url을 라우팅 하지는 않고, setting 하려는 타입에 따라 setting content만 다르게 렌더링 하도록 하였습니다.
- 하지만 style의 경우 대부분 유사하므로, styles파일에 공통적인 것을 모아서 사용하도록 refactoring할 예정입니다.

아래의 각 탭에서 설정할 컨텐츠들을 보여주고, 각각 API와 연동하면 될 것 같습니다.


![스크린샷 2020-12-07 오후 5 40 35](https://user-images.githubusercontent.com/49441876/101328445-587fbd00-38b3-11eb-97ab-a2816c97c02a.png)



<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
