### PR TITLE
[FE, BE] CSV로 거래내역 export, import

### DIFF
--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -197,6 +197,11 @@
         "@types/express": "*"
       }
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+    },
     "@types/express": {
       "version": "4.17.9",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
@@ -218,6 +223,15 @@
         "@types/node": "*",
         "@types/qs": "*",
         "@types/range-parser": "*"
+      }
+    },
+    "@types/formidable": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@types/formidable/-/formidable-1.0.31.tgz",
+      "integrity": "sha512-dIhM5t8lRP0oWe2HF8MuPvdd1TpPTjhDMAqemcq6oIZQCBQTovhBAdTQ5L5veJB4pdQChadmHuxtB0YzqvfU3Q==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
       }
     },
     "@types/http-assert": {
@@ -353,8 +367,7 @@
     "@types/node": {
       "version": "14.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz",
-      "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==",
-      "dev": true
+      "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA=="
     },
     "@types/qs": {
       "version": "6.9.5",
@@ -1691,6 +1704,11 @@
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
       "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
     },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -2293,6 +2311,29 @@
         "statuses": "^1.5.0",
         "type-is": "^1.6.16",
         "vary": "^1.1.2"
+      }
+    },
+    "koa-body": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/koa-body/-/koa-body-4.2.0.tgz",
+      "integrity": "sha512-wdGu7b9amk4Fnk/ytH8GuWwfs4fsB5iNkY8kZPpgQVb04QZSv85T0M8reb+cJmvLE8cjPYvBzRikD3s6qz8OoA==",
+      "requires": {
+        "@types/formidable": "^1.0.31",
+        "co-body": "^5.1.1",
+        "formidable": "^1.1.1"
+      },
+      "dependencies": {
+        "co-body": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/co-body/-/co-body-5.2.0.tgz",
+          "integrity": "sha512-sX/LQ7LqUhgyaxzbe7IqwPeTr2yfpfUIQ/dgpKo6ZI4y4lpQA0YxAomWIY+7I7rHWcG02PG+OuPREzMW/5tszQ==",
+          "requires": {
+            "inflation": "^2.0.0",
+            "qs": "^6.4.0",
+            "raw-body": "^2.2.0",
+            "type-is": "^1.6.14"
+          }
+        }
       }
     },
     "koa-bodyparser": {

--- a/BE/package-lock.json
+++ b/BE/package-lock.json
@@ -987,6 +987,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2167,6 +2172,16 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json2csv": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.5.tgz",
+      "integrity": "sha512-/UyvnfuUghRM+C/AiQ02X0LS+/AKfugcwaWo/gAz1pi203v29sUMrMSNEC088i+h0EG39eSsmeL9Z0iK+9MM0A==",
+      "requires": {
+        "commander": "^6.1.0",
+        "jsonparse": "^1.3.1",
+        "lodash.get": "^4.4.2"
+      }
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -2174,6 +2189,11 @@
       "requires": {
         "minimist": "^1.2.0"
       }
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -2404,6 +2424,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
       "version": "4.3.0",

--- a/BE/package.json
+++ b/BE/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "http-errors": "^1.8.0",
+    "json2csv": "^5.0.5",
     "jsonwebtoken": "^8.5.1",
     "koa": "2.13.0",
     "koa-bodyparser": "^4.3.0",

--- a/BE/package.json
+++ b/BE/package.json
@@ -20,6 +20,7 @@
     "json2csv": "^5.0.5",
     "jsonwebtoken": "^8.5.1",
     "koa": "2.13.0",
+    "koa-body": "^4.2.0",
     "koa-bodyparser": "^4.3.0",
     "koa-logger": "^3.2.1",
     "koa-router": "10.0.0",

--- a/BE/src/controllers/transaction.ts
+++ b/BE/src/controllers/transaction.ts
@@ -13,6 +13,7 @@ const exportCSV = async (ctx: Context): Promise<Context['body']> => {
 const importCSV = async (ctx: Context): Promise<Context['body']> => {
   const result = await service.importCSV(ctx);
   const csv = result.data;
+  console.log('!', csv);
   for (var token of csv) {
     console.log('나와');
   }

--- a/BE/src/controllers/transaction.ts
+++ b/BE/src/controllers/transaction.ts
@@ -3,10 +3,22 @@ import service from '@services/transaction';
 import { response } from '@utils/response';
 
 const exportCSV = async (ctx: Context): Promise<Context['body']> => {
-  const csv = await service.transactionCsv(ctx);
+  const csv = await service.exportCSV(ctx);
   const res = response(200, csv.message, csv.data);
   ctx.body = res;
-  // ctx.body = `/GET ${ctx.url}`;
+
+  return ctx.body;
+};
+
+const importCSV = async (ctx: Context): Promise<Context['body']> => {
+  const result = await service.importCSV(ctx);
+  const csv = result.data;
+  for (var token of csv) {
+    console.log('나와');
+  }
+  const res = response(200, result.message, result.data);
+  ctx.body = res;
+
   return ctx.body;
 };
 
@@ -14,11 +26,6 @@ const post = async (ctx: Context): Promise<Context['body']> => {
   const transaction = await service.post(ctx);
   const res = response(200, transaction.message, transaction.data);
   ctx.body = res;
-  return ctx.body;
-};
-
-const importCSV = async (ctx: Context): Promise<Context['body']> => {
-  ctx.body = `/POST ${ctx.url}`;
   return ctx.body;
 };
 

--- a/BE/src/controllers/transaction.ts
+++ b/BE/src/controllers/transaction.ts
@@ -11,16 +11,14 @@ const exportCSV = async (ctx: Context): Promise<Context['body']> => {
 };
 
 const importCSV = async (ctx: Context): Promise<Context['body']> => {
-  const result = await service.importCSV(ctx);
-  const csv = result.data;
-  console.log('!', csv);
-  for (var token of csv) {
-    console.log('나와');
-  }
-  const res = response(200, result.message, result.data);
-  ctx.body = res;
+  const csv = await service.importCSV(ctx);
+  if (csv.message === 'success') {
+    const res = response(200, csv.message, csv.data);
+    ctx.body = res;
 
-  return ctx.body;
+    return ctx.body;
+  }
+  ctx.throw(400, csv.message);
 };
 
 const post = async (ctx: Context): Promise<Context['body']> => {

--- a/BE/src/controllers/transaction.ts
+++ b/BE/src/controllers/transaction.ts
@@ -3,7 +3,10 @@ import service from '@services/transaction';
 import { response } from '@utils/response';
 
 const exportCSV = async (ctx: Context): Promise<Context['body']> => {
-  ctx.body = `/GET ${ctx.url}`;
+  const csv = await service.transactionCsv(ctx);
+  const res = response(200, csv.message, csv.data);
+  ctx.body = res;
+  // ctx.body = `/GET ${ctx.url}`;
   return ctx.body;
 };
 

--- a/BE/src/models/accountbook/index.ts
+++ b/BE/src/models/accountbook/index.ts
@@ -107,6 +107,25 @@ const addTransaction = async (
   return false;
 };
 
+const addTransactions = async (
+  accountBookId: string,
+  transactionArray: any,
+): Promise<any> => {
+  const curAccountBook = await AccountBookModel.findOne({ _id: accountBookId });
+  if (curAccountBook) {
+    const curTransactions = curAccountBook.transactions;
+    const updateResult = await AccountBookModel.update(
+      { _id: accountBookId },
+      { transactions: [...curTransactions, ...transactionArray] },
+    );
+    if (updateResult.nModified) {
+      return curTransactions[curTransactions.length - 1];
+    }
+    return false;
+  }
+  return false;
+};
+
 const updateTransaction = async (
   accountBookId: string,
   transactionId: string,
@@ -277,6 +296,7 @@ export default {
   updateStartday,
   del,
   addTransaction,
+  addTransactions,
   updateTransaction,
   deleteTransaction,
   addPaymentMethod,

--- a/BE/src/routes/api/account-book/transaction.ts
+++ b/BE/src/routes/api/account-book/transaction.ts
@@ -1,4 +1,5 @@
 import Router from 'koa-router';
+import koaBody from 'koa-body';
 
 import Controller from '@controllers/transaction';
 
@@ -8,7 +9,7 @@ const router = new Router();
 
 router.get('/csv', Controller.exportCSV);
 router.post('/', Controller.post);
-router.post('/csv', Controller.importCSV);
+router.post('/csv', koaBody({ multipart: true }), Controller.importCSV);
 router.patch('/:transactionid', Controller.patch);
 router.delete('/:transactionid', Controller.del);
 

--- a/BE/src/services/transaction.ts
+++ b/BE/src/services/transaction.ts
@@ -80,7 +80,7 @@ const transactionCsv = async (ctx: Context): Promise<any> => {
     ctx.params.accountbookid,
   );
   const transactions = accountBook.transactions;
-  console.log('transactions', typeof transactions);
+  console.log('transactions', transactions);
 
   if (transactions) {
     const fields = [
@@ -96,10 +96,9 @@ const transactionCsv = async (ctx: Context): Promise<any> => {
     ];
     const json2csvParser = new Parser({ fields });
     const csv = json2csvParser.parse(transactions);
-    console.log(csv);
     return {
       message: 'success',
-      data: transactions,
+      data: csv,
     };
   }
   return {

--- a/BE/src/services/transaction.ts
+++ b/BE/src/services/transaction.ts
@@ -1,5 +1,6 @@
 import accountBookModel from '@models/accountbook';
 import { Context } from 'koa';
+
 const { Parser } = require('json2csv');
 
 const post = async (ctx: Context): Promise<any> => {
@@ -75,7 +76,7 @@ const del = async (ctx: Context): Promise<any> => {
   };
 };
 
-const transactionCsv = async (ctx: Context): Promise<any> => {
+const exportCSV = async (ctx: Context): Promise<any> => {
   const accountBook = await accountBookModel.getDetail(
     ctx.params.accountbookid,
   );
@@ -107,4 +108,18 @@ const transactionCsv = async (ctx: Context): Promise<any> => {
   };
 };
 
-export default { post, patch, del, transactionCsv };
+const importCSV = async (ctx: Context): Promise<any> => {
+  if (ctx) {
+    console.log(ctx.request.files);
+    return {
+      message: 'success',
+      data: ctx.request.files,
+    };
+  }
+  return {
+    message: 'fail',
+    data: {},
+  };
+};
+
+export default { post, patch, del, exportCSV, importCSV };

--- a/BE/src/services/transaction.ts
+++ b/BE/src/services/transaction.ts
@@ -1,5 +1,6 @@
 import accountBookModel from '@models/accountbook';
 import { Context } from 'koa';
+const { Parser } = require('json2csv');
 
 const post = async (ctx: Context): Promise<any> => {
   const transactionInfo = {
@@ -74,4 +75,37 @@ const del = async (ctx: Context): Promise<any> => {
   };
 };
 
-export default { post, patch, del };
+const transactionCsv = async (ctx: Context): Promise<any> => {
+  const accountBook = await accountBookModel.getDetail(
+    ctx.params.accountbookid,
+  );
+  const transactions = accountBook.transactions;
+  console.log('transactions', typeof transactions);
+
+  if (transactions) {
+    const fields = [
+      'content',
+      'type',
+      'cost',
+      'date',
+      'category.name',
+      'category.icon',
+      'category.type',
+      'payment.name',
+      'payment.color',
+    ];
+    const json2csvParser = new Parser({ fields });
+    const csv = json2csvParser.parse(transactions);
+    console.log(csv);
+    return {
+      message: 'success',
+      data: transactions,
+    };
+  }
+  return {
+    message: 'fail',
+    data: {},
+  };
+};
+
+export default { post, patch, del, transactionCsv };

--- a/BE/src/services/transaction.ts
+++ b/BE/src/services/transaction.ts
@@ -109,8 +109,12 @@ const exportCSV = async (ctx: Context): Promise<any> => {
 };
 
 const importCSV = async (ctx: Context): Promise<any> => {
-  if (ctx) {
-    console.log(ctx.request.files);
+  if (ctx) {    
+    const csvDatas = ctx.request.body;
+    const csvLength = ctx.request.body.csvLength;
+    console.log(csvDatas, csvLength);
+    // console.log(csvDatas.split(','));
+
     return {
       message: 'success',
       data: ctx.request.files,

--- a/BE/src/utils/export.js
+++ b/BE/src/utils/export.js
@@ -1,0 +1,176 @@
+const fs = require('fs');
+const { Parser } = require('json2csv');
+
+const chars = 'qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM';
+const randomNum = (num, devide) =>
+  Math.floor((Math.random() * num) % devide) + 1;
+
+const makeWord = () => {
+  const n = randomNum(100, 15);
+  let str = '';
+  for (let i = 0; i < n; ++i) {
+    str += chars[randomNum(100, 52) - 1];
+  }
+  return str;
+};
+
+const makeType = () => {
+  const n = randomNum(100, 2) - 1;
+  if (n) return '수입';
+  else return '지출';
+};
+const makeDate = () => {
+  const month = randomNum(100, 12);
+  const date = randomNum(100, 30);
+  return `2020-12-${date}`;
+};
+
+const makeCategory = () => {
+  const icon = randomNum(100, 10);
+  switch (icon) {
+    case 1:
+      return {
+        name: '월급',
+        icon: 1,
+        type: '수입',
+      };
+    case 2:
+      return {
+        name: '용돈',
+        icon: 2,
+        type: '지출',
+      };
+    case 3:
+      return {
+        name: '기타수입',
+        icon: 3,
+        type: '수입',
+      };
+    case 4:
+      return {
+        name: '식비',
+        icon: 4,
+        type: '지출',
+      };
+    case 5:
+      return {
+        name: '생활',
+        icon: 5,
+        type: '지출',
+      };
+    case 6:
+      return {
+        name: '쇼핑/뷰티',
+        icon: 6,
+        type: '지출',
+      };
+    case 7:
+      return {
+        name: '교통',
+        icon: 7,
+        type: '지출',
+      };
+    case 8:
+      return {
+        name: '의료/건강',
+        icon: 8,
+        type: '지출',
+      };
+    case 9:
+      return {
+        name: '문화/여가',
+        icon: 9,
+        type: '지출',
+      };
+    case 10:
+      return {
+        name: '미분류',
+        icon: 10,
+        type: '지출',
+      };
+  }
+};
+
+const makepayment = () => {
+  const card = randomNum(100, 9);
+  switch (card) {
+    case 1:
+      return {
+        name: 'KB',
+        color: 'hsla(0, 100%, 50%, 0.93)',
+      };
+    case 2:
+      return {
+        name: 'Kakao',
+        color: 'hsla(40, 100%, 50%, 0.93)',
+      };
+    case 3:
+      return {
+        name: 'SC 제일은행',
+        color: 'hsla(80, 100%, 50%, 0.93)',
+      };
+    case 4:
+      return {
+        name: 'Naver',
+        color: 'hsla(120, 100%, 50%, 0.93)',
+      };
+    case 5:
+      return {
+        name: 'KEB Hana',
+        color: 'hsla(160, 100%, 50%, 0.93)',
+      };
+    case 6:
+      return {
+        name: 'WOORI Card',
+        color: 'hsla(200, 100%, 50%, 0.93)',
+      };
+    case 7:
+      return {
+        name: 'Samsung',
+        color: 'hsla(240, 100%, 50%, 0.93)',
+      };
+    case 8:
+      return {
+        name: 'Hyundai',
+        color: 'hsla(280, 100%, 50%, 0.93)',
+      };
+    case 9:
+      return {
+        name: 'BC Card',
+        color: 'hsla(320, 100%, 50%, 0.93)',
+      };
+  }
+};
+
+const init = args => {
+  let transactions = [];
+  for (let i = 0; i < args; ++i) {
+    const transaction = {
+      content: makeWord(),
+      type: makeType(),
+      cost: randomNum(100000, 100000),
+      date: makeDate(),
+      category: makeCategory(),
+      payment: makepayment(),
+    };
+    transactions.push(transaction);
+  }
+  let jsonTransactions = JSON.stringify(transactions, null, 2);
+  const fields = [
+    'content',
+    'type',
+    'cost',
+    'date',
+    'category.name',
+    'category.icon',
+    'category.type',
+    'payment.name',
+    'payment.color',
+  ];
+  const json2csvParser = new Parser({ fields });
+  const csv = json2csvParser.parse(transactions);
+  console.log(csv);
+  fs.writeFileSync('transaction.csv', csv);
+};
+
+init(process.argv[2]);

--- a/BE/src/utils/transaction.csv
+++ b/BE/src/utils/transaction.csv
@@ -1,0 +1,4 @@
+"content","type","cost","date","category.name","category.icon","category.type","payment.name","payment.color"
+"xZ","지출",2010,"2020-12-21","문화/여가",9,"지출","KEB Hana","hsla(160, 100%, 50%, 0.93)"
+"cbbAHhuHQhju","수입",82333,"2020-12-28","미분류",10,"지출","WOORI Card","hsla(200, 100%, 50%, 0.93)"
+"RKIDJf","지출",65512,"2020-12-2","미분류",10,"지출","BC Card","hsla(320, 100%, 50%, 0.93)"

--- a/BE/src/utils/transaction.json
+++ b/BE/src/utils/transaction.json
@@ -1,0 +1,47 @@
+[
+  {
+    "content": "QYek",
+    "type": "지출",
+    "cost": 22633,
+    "date": "2020-12-28",
+    "category": {
+      "name": "용돈",
+      "icon": 2,
+      "type": "지출"
+    },
+    "payment": {
+      "name": "Kakao",
+      "color": "hsla(40, 100%, 50%, 0.93)"
+    }
+  },
+  {
+    "content": "XCgZLnnNh",
+    "type": "지출",
+    "cost": 63127,
+    "date": "2020-12-4",
+    "category": {
+      "name": "미분류",
+      "icon": 10,
+      "type": "지출"
+    },
+    "payment": {
+      "name": "Hyundai",
+      "color": "hsla(280, 100%, 50%, 0.93)"
+    }
+  },
+  {
+    "content": "EASQAiXMsTu",
+    "type": "지출",
+    "cost": 29606,
+    "date": "2020-12-18",
+    "category": {
+      "name": "식비",
+      "icon": 4,
+      "type": "지출"
+    },
+    "payment": {
+      "name": "SC 제일은행",
+      "color": "hsla(80, 100%, 50%, 0.93)"
+    }
+  }
+]

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -1447,14 +1447,21 @@
     "@types/node": {
       "version": "14.14.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.8.tgz",
-      "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA==",
-      "dev": true
+      "integrity": "sha512-z/5Yd59dCKI5kbxauAJgw6dLPzW+TNOItNE00PkpzNwUIEwdj/Lsqwq94H5DdYBX7C13aRA0CY32BK76+neEUA=="
     },
     "@types/node-sass": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/@types/node-sass/-/node-sass-4.11.1.tgz",
       "integrity": "sha512-wPOmOEEtbwQiPTIgzUuRSQZ3H5YHinsxRGeZzPSDefAm4ylXWnZG9C0adses8ymyplKK0gwv3JkDNO8GGxnWfg==",
       "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/papaparse": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.2.4.tgz",
+      "integrity": "sha512-oxwvNgW/RwtGsU/TOlV1zwBfozuyav0BotfCt0mX83nk87tePauU7N7shjI7uCBaPTEVip/F6XLfvs+Bk8M5HQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -7966,6 +7973,11 @@
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
+    "papaparse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.0.tgz",
+      "integrity": "sha512-Lb7jN/4bTpiuGPrYy4tkKoUS8sTki8zacB5ke1p5zolhcSE4TlWgrlsxjrDTbG/dFVh07ck7X36hUf/b5V68pg=="
+    },
     "parallel-transform": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
@@ -8604,6 +8616,15 @@
       "requires": {
         "lodash": "^4.17.19",
         "prop-types": "^15.7.2"
+      }
+    },
+    "react-csv-reader": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-csv-reader/-/react-csv-reader-3.1.1.tgz",
+      "integrity": "sha512-rPe7/aMT8W0VAkdiXQwC14wjyVP1hejRzLT344Hpu4LACL1YoDPD6AANkHFfC5YMmpDExlgp0XQZCBkJAAdAsQ==",
+      "requires": {
+        "@types/papaparse": "^5.0.3",
+        "papaparse": "^5.1.1"
       }
     },
     "react-dom": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -19,6 +19,7 @@
     "mobx-react": "^7.0.5",
     "react": "^17.0.1",
     "react-chartjs-2": "^2.11.1",
+    "react-csv-reader": "^3.1.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "sass": "^1.29.0",

--- a/FE/src/api/csv.ts
+++ b/FE/src/api/csv.ts
@@ -1,0 +1,9 @@
+import { getFetch, postFetch } from '../service/fetch';
+
+export default function getTransactionCSV(id) {
+  const data = getFetch(
+    `${process.env.SERVER_URL}/api/accountbook/${id}/transaction/csv`,
+  );
+
+  return data;
+}

--- a/FE/src/api/csv.ts
+++ b/FE/src/api/csv.ts
@@ -1,9 +1,25 @@
 import { getFetch, postFetch } from '../service/fetch';
 
-export default function getTransactionCSV(id) {
+export const getTransactionCSV = id => {
   const data = getFetch(
     `${process.env.SERVER_URL}/api/accountbook/${id}/transaction/csv`,
   );
 
   return data;
-}
+};
+
+export const postTransactionCSV = (id, formData) => {
+  const data = fetch(
+    `${process.env.SERVER_URL}/api/accountbook/${id}/transaction/csv`,
+    {
+      method: 'POST',
+      body: formData,
+      headers: {
+        'Cotent-type': 'multipart/form-data',
+        Authorization: `Bearer ${window.localStorage.getItem('token')}`,
+      },
+    },
+  );
+
+  return data;
+};

--- a/FE/src/api/csv.ts
+++ b/FE/src/api/csv.ts
@@ -8,17 +8,10 @@ export const getTransactionCSV = id => {
   return data;
 };
 
-export const postTransactionCSV = (id, body) => {
-  const data = fetch(
+export const postTransactionCSV = async (id, body) => {
+  const data = await postFetch(
     `${process.env.SERVER_URL}/api/accountbook/${id}/transaction/csv`,
-    {
-      method: 'POST',
-      body: JSON.stringify(body),
-      headers: {
-        'Cotent-type': 'application/json',
-        Authorization: `Bearer ${window.localStorage.getItem('token')}`,
-      },
-    },
+    body,
   );
 
   return data;

--- a/FE/src/api/csv.ts
+++ b/FE/src/api/csv.ts
@@ -8,14 +8,14 @@ export const getTransactionCSV = id => {
   return data;
 };
 
-export const postTransactionCSV = (id, formData) => {
+export const postTransactionCSV = (id, body) => {
   const data = fetch(
     `${process.env.SERVER_URL}/api/accountbook/${id}/transaction/csv`,
     {
       method: 'POST',
-      body: formData,
+      body: JSON.stringify(body),
       headers: {
-        'Cotent-type': 'multipart/form-data',
+        'Cotent-type': 'application/json',
         Authorization: `Bearer ${window.localStorage.getItem('token')}`,
       },
     },

--- a/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
+++ b/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
@@ -1,3 +1,29 @@
 .csv__setting__container {
   color: white;
+  display: flex;
+  justify-content: space-evenly;
+
+  .csv__export {
+    background: transparent;
+    color: white;
+    border: 1px 0 0 10px #219cf3 solid;
+    box-shadow: none;
+    border-radius: 16px;
+    padding: 16px;
+    overflow: visible;
+    cursor: pointer;
+    text-shadow: 0 0 10px #219cf3, 0 0 10px #219cf3;
+  }
+
+  .csv__import {
+    background: transparent;
+    color: white;
+    border: 1px 0 0 10px #219cf3 solid;
+    box-shadow: none;
+    border-radius: 16px;
+    padding: 16px;
+    overflow: visible;
+    cursor: pointer;
+    text-shadow: 0 0 10px #219cf3, 0 0 10px #219cf3;
+  }
 }

--- a/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
+++ b/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
@@ -21,7 +21,7 @@
     display: flex;
     flex-direction: column;
 
-    > input {
+    .csv-input {
       margin-bottom: 10px;
     }
 

--- a/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
+++ b/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
@@ -2,9 +2,11 @@
   color: white;
   display: flex;
   justify-content: space-evenly;
+  align-items: center;
 
   .csv__export {
     background: transparent;
+    height: 54px;
     color: white;
     border: 1px 0 0 10px #219cf3 solid;
     box-shadow: none;
@@ -15,15 +17,25 @@
     text-shadow: 0 0 10px #219cf3, 0 0 10px #219cf3;
   }
 
-  .csv__import {
-    background: transparent;
-    color: white;
-    border: 1px 0 0 10px #219cf3 solid;
-    box-shadow: none;
-    border-radius: 16px;
-    padding: 16px;
-    overflow: visible;
-    cursor: pointer;
-    text-shadow: 0 0 10px #219cf3, 0 0 10px #219cf3;
+  .csv__import__form {
+    display: flex;
+    flex-direction: column;
+
+    > input {
+      margin-bottom: 10px;
+    }
+
+    .csv__import {
+      background: transparent;
+      color: white;
+      width: 216px;
+      border: 1px 0 0 10px #219cf3 solid;
+      box-shadow: none;
+      border-radius: 16px;
+      padding: 16px;
+      overflow: visible;
+      cursor: pointer;
+      text-shadow: 0 0 10px #219cf3, 0 0 10px #219cf3;
+    }
   }
 }

--- a/FE/src/components/SettingContent/CSVSetting/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/index.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import { useHistory } from 'react-router-dom';
 
 import './csvSetting.scss';
+import getTransactionCSV from '../../../api/csv';
+import exportToCSV from '../../../service/export';
 
 export default function CSVSetting(props) {
-  return <div className="csv__setting__container">csv</div>;
+  const accountBookId = useHistory().location.state.id;
+
+  const downloadCSV = async () => {
+    const response = await getTransactionCSV(accountBookId);
+    const csv = response.data;
+    exportToCSV(csv);
+  };
+
+  return (
+    <div className="csv__setting__container">
+      <button className="csv__export" onClick={downloadCSV}>
+        거래내역 CSV File로 다운받기
+      </button>
+      <button className="csv__import">거래내역 CSV File로 추가하기</button>
+    </div>
+  );
 }

--- a/FE/src/components/SettingContent/CSVSetting/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/index.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import CSVReader from 'react-csv-reader'
 
 import './csvSetting.scss';
 import { getTransactionCSV, postTransactionCSV } from '../../../api/csv';
@@ -16,15 +17,13 @@ export default function CSVSetting(props) {
 
   const [file, setFile] = useState('import하고싶다');
 
-  const fileChangeHandler = event => {
-    const uploadFile = event.target.files;
+  const fileChangeHandler = data => {
+    const uploadFile = data;
     setFile(uploadFile);
   };
 
   const onClickHandler = event => {
-    const formData = new FormData();
-    formData.append('importCSV', file);
-    postTransactionCSV(accountBookId, formData);
+    postTransactionCSV(accountBookId, file);
   };
 
   return (
@@ -37,6 +36,7 @@ export default function CSVSetting(props) {
         <button className="csv__import" onClick={onClickHandler}>
           거래내역 CSV File로 추가하기
         </button>
+        <CSVReader onFileLoaded={(data) => fileChangeHandler(data)} />
       </div>
     </div>
   );

--- a/FE/src/components/SettingContent/CSVSetting/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import CSVReader from 'react-csv-reader'
+import CSVReader from 'react-csv-reader';
 
 import './csvSetting.scss';
 import { getTransactionCSV, postTransactionCSV } from '../../../api/csv';
@@ -15,7 +15,7 @@ export default function CSVSetting(props) {
     exportToCSV(csv);
   };
 
-  const [file, setFile] = useState('import하고싶다');
+  const [file, setFile] = useState('');
 
   const fileChangeHandler = data => {
     const uploadFile = data;
@@ -23,7 +23,9 @@ export default function CSVSetting(props) {
   };
 
   const onClickHandler = event => {
-    postTransactionCSV(accountBookId, file);
+    if (file !== '') {
+      postTransactionCSV(accountBookId, file);
+    }
   };
 
   return (
@@ -32,11 +34,10 @@ export default function CSVSetting(props) {
         거래내역 CSV File로 다운받기
       </button>
       <div className="csv__import__form">
-        <input type="file" multiple onChange={fileChangeHandler} />
+        <CSVReader onFileLoaded={data => fileChangeHandler(data)} />
         <button className="csv__import" onClick={onClickHandler}>
           거래내역 CSV File로 추가하기
         </button>
-        <CSVReader onFileLoaded={(data) => fileChangeHandler(data)} />
       </div>
     </div>
   );

--- a/FE/src/components/SettingContent/CSVSetting/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/index.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
 import './csvSetting.scss';
-import getTransactionCSV from '../../../api/csv';
+import { getTransactionCSV, postTransactionCSV } from '../../../api/csv';
 import exportToCSV from '../../../service/export';
 
 export default function CSVSetting(props) {
@@ -14,12 +14,30 @@ export default function CSVSetting(props) {
     exportToCSV(csv);
   };
 
+  const [file, setFile] = useState('import하고싶다');
+
+  const fileChangeHandler = event => {
+    const uploadFile = event.target.files;
+    setFile(uploadFile);
+  };
+
+  const onClickHandler = event => {
+    const formData = new FormData();
+    formData.append('importCSV', file);
+    postTransactionCSV(accountBookId, formData);
+  };
+
   return (
     <div className="csv__setting__container">
       <button className="csv__export" onClick={downloadCSV}>
         거래내역 CSV File로 다운받기
       </button>
-      <button className="csv__import">거래내역 CSV File로 추가하기</button>
+      <div className="csv__import__form">
+        <input type="file" multiple onChange={fileChangeHandler} />
+        <button className="csv__import" onClick={onClickHandler}>
+          거래내역 CSV File로 추가하기
+        </button>
+      </div>
     </div>
   );
 }

--- a/FE/src/components/SettingContent/CSVSetting/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/index.tsx
@@ -22,9 +22,9 @@ export default function CSVSetting(props) {
     setFile(uploadFile);
   };
 
-  const onClickHandler = event => {
+  const onClickHandler = async event => {
     if (file !== '') {
-      postTransactionCSV(accountBookId, file);
+      await postTransactionCSV(accountBookId, file);
     }
   };
 

--- a/FE/src/service/export.ts
+++ b/FE/src/service/export.ts
@@ -1,0 +1,37 @@
+export default function exportToCSV(csv) {
+  const filename = 'transactions.csv';
+  if (window.navigator && window.navigator.msSaveOrOpenBlob) {
+    console.log('if');
+    let blob = new Blob([decodeURIComponent(csv)], {
+      type: 'text/csv;charset=utf8',
+    });
+
+    window.navigator.msSaveOrOpenBlob(blob, filename);
+  } else if (window.Blob && window.URL) {
+    //HTML5 Blob
+    console.log('else if');
+    let blob = new Blob([csv], { type: 'text/csv;charset=utf8' });
+    let csvUrl = URL.createObjectURL(blob);
+    let a = document.createElement('a');
+    a.setAttribute('style', 'display:none');
+    a.setAttribute('href', csvUrl);
+    a.setAttribute('download', filename);
+    document.body.appendChild(a);
+
+    a.click();
+    a.remove();
+  } else {
+    // Data URI
+    console.log('else');
+    let csvData =
+      'data:application/csv;charset=utf-8,' + encodeURIComponent(csv);
+    let a = document.createElement('a');
+    a.setAttribute('style', 'display:none');
+    a.setAttribute('target', '_blank');
+    a.setAttribute('href', csvData);
+    a.setAttribute('download', filename);
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  }
+}

--- a/FE/src/service/fetch.ts
+++ b/FE/src/service/fetch.ts
@@ -20,6 +20,7 @@ export const postFetch = async (query, body) => {
     },
     body: JSON.stringify(body),
   });
+
   const json = response.json();
   return json;
 };
@@ -33,8 +34,9 @@ export const updateFetch = async (query, body) => {
     },
     body: JSON.stringify(body),
   });
-  const json = response.json();
-  return json;
+
+  // const json = response.json();
+  return response;
 };
 
 export const deleteFetch = async (query, body) => {
@@ -46,6 +48,7 @@ export const deleteFetch = async (query, body) => {
     },
     body: JSON.stringify(body),
   });
+
   const json = response.json();
   return json;
 };


### PR DESCRIPTION
### 📕 Issue Number

Close #101 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] GET: api/accountbook/:accountbookId/transaction/csv 로 GET 요청이 오면 csv 형태로 반환
- [x] 프론트와 export 연동하여 버튼 클릭 시 다운로드
- [x] FE에 파일 첨부하여 POST: api/accountbook/:accountbookId/transaction/csv 로 import 요청
- [x] 요청이 오면 BE에서 DB 생성
- [x] 옳지 않은 csv 형식이면 400 error 발생

> 고민했던 점

-  FE에서 csv파일을 첨부할 시 array 형태로 바꿔주는 라이브러리를 사용하였다. 통째로 BE에 보내주어서 BE에서 열어보고 싶었지만 FE에서 파일 내용을 열어서 첨부하지 않으면 string으로 자동변환되어 확인할 수 없는 문제가 있었다.
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
