### PR TITLE
[FE] Layout refactor

### DIFF
--- a/BE/package.json
+++ b/BE/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
-    "start": "tsc && export PRODUCTION=true && node -r ./tsconfig-paths-bootstrap.js build/index.js",
+    "start": " tsc && export PRODUCTION=true && node -r ./tsconfig-paths-bootstrap.js build/index.js",
     "dev": "nodemon"
   },
   "author": "",

--- a/BE/src/interfaces/auth.ts
+++ b/BE/src/interfaces/auth.ts
@@ -11,7 +11,6 @@ export interface User {
   social: string;
   profile: string;
   name?: string;
-  profile: string;
 }
 
 export interface iOAuth {

--- a/FE/src/components/Common/MenuBar/menubar.scss
+++ b/FE/src/components/Common/MenuBar/menubar.scss
@@ -3,28 +3,8 @@
 @use '../../../styles/mediaQuery' as *;
 
 @mixin navigationButton($type) {
-  @include buttonDefaultSetting;
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  @include headerNavigationButtons($type);
 
-  text-align: center;
-  line-height: 1.5em;
-  @if $type== list {
-    left: 5%;
-  } @else {
-    right: 5%;
-  }
-  height: 1.5em;
-  background-color: transparent;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 0.5em;
-  font-size: 1.5em;
-
-  text-shadow: $selectedTextShadow;
-  color: white;
   @include mobile {
     .navigation__content {
       display: none;
@@ -36,23 +16,14 @@
 }
 
 .menubar__header {
-  position: relative;
-  background-color: $dark-background-color;
-  width: 100%;
-
-  padding-top: 2.5%;
-  z-index: 2;
+  @include headerSetting;
   .menubar__buttons {
-    display: flex;
-    justify-content: center;
-    gap: 3em;
-    position: relative;
-
+    @include headerButtons;
     .back__navBtn {
-      @include navigationButton(list);
+      @include navigationButton(left);
     }
     .setting__navBtn {
-      @include navigationButton(setting);
+      @include navigationButton(right);
     }
     @include mobile {
       .back__navBtn,
@@ -74,7 +45,7 @@
     justify-content: center;
     gap: 2em;
     font-weight: 900;
-    color: white;
+    color: $dark-emphasize-font-color;
     text-shadow: $selectedTextShadow;
 
     .btn-cal {
@@ -87,7 +58,7 @@
       font-size: 16px;
       background: none;
       font-weight: 900;
-      color: white;
+      color: $dark-emphasize-font-color;
       text-shadow: $selectedTextShadow;
     }
     .btn-cal:after {

--- a/FE/src/components/SettingBar/index.tsx
+++ b/FE/src/components/SettingBar/index.tsx
@@ -33,7 +33,9 @@ export default function SettingBar({
           onClick={onClickBackBtn}
         >
           <i data-type="/calendar" className="fas fa-arrow-left" />
-          <span data-type="/calendar">Account Book</span>
+          <span className="nav__accountbook__btn" data-type="/calendar">
+            Account Book
+          </span>
         </div>
         {settingType === 'user' ? (
           <HeaderButton buttonType="user" isChecked onClickIcon={onClickIcon} />

--- a/FE/src/components/SettingBar/settingBar.scss
+++ b/FE/src/components/SettingBar/settingBar.scss
@@ -3,37 +3,13 @@
 @use '../../styles/mediaQuery' as *;
 
 .settingbar__header {
-  background-color: $dark-background-color;
-  width: 100%;
-  height: 20%;
-  padding: 2.5em 0;
-  z-index: 2;
-  overflow-x: hidden;
+  @include headerSetting;
+
   .settingbar__buttons {
-    display: flex;
-    justify-content: center;
-    gap: 3em;
-    position: relative;
+    @include headerButtons;
 
     .settingbar__back__navBtn {
-      @include buttonDefaultSetting;
-      position: absolute;
-      top: 50%;
-      transform: translateY(-50%);
-      left: 5%;
-      text-align: center;
-      line-height: 1.5em;
-
-      height: 1.5em;
-      background-color: transparent;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      gap: 0.5em;
-      font-size: 1.5em;
-
-      text-shadow: $selectedTextShadow;
-      color: $dark-emphasize-font-color;
+      @include headerNavigationButtons(left);
     }
     @include mobile {
       .settingbar__back__navBtn {

--- a/FE/src/components/SettingBar/settingBar.scss
+++ b/FE/src/components/SettingBar/settingBar.scss
@@ -1,5 +1,6 @@
 @use '../../styles/values' as *;
 @use '../../styles/mixins' as *;
+@use '../../styles/mediaQuery' as *;
 
 .settingbar__header {
   background-color: $dark-background-color;
@@ -19,7 +20,7 @@
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
-      left: 2%;
+      left: 5%;
       text-align: center;
       line-height: 1.5em;
 
@@ -33,6 +34,21 @@
 
       text-shadow: $selectedTextShadow;
       color: $dark-emphasize-font-color;
+    }
+    @include mobile {
+      .settingbar__back__navBtn {
+        .nav__accountbook__btn {
+          display: none;
+        }
+        .fas.fa-arrow-left {
+          font-size: 1rem;
+        }
+      }
+    }
+  }
+  @include mobile {
+    .settingbar__buttons {
+      gap: 1em;
     }
   }
 }

--- a/FE/src/components/SettingContent/CSVSetting/CSVExport/csvExport.scss
+++ b/FE/src/components/SettingContent/CSVSetting/CSVExport/csvExport.scss
@@ -5,8 +5,13 @@
   @include settingBox;
 
   .csv__export__title {
-    font-size: 1.5em;
-    padding: 1em;
-    text-shadow: $selectedTextShadow;
+    @include settingTitle;
+  }
+  .csv__export__desc {
+    @include settingDesc;
+  }
+  .csv__export__btn {
+    display: flex;
+    justify-content: center;
   }
 }

--- a/FE/src/components/SettingContent/CSVSetting/CSVExport/csvExport.scss
+++ b/FE/src/components/SettingContent/CSVSetting/CSVExport/csvExport.scss
@@ -1,0 +1,12 @@
+@use '../../../../styles/values'as *;
+@use '../../../../styles/mixins'as *;
+
+.csv__export__box {
+  @include settingBox;
+
+  .csv__export__title {
+    font-size: 1.5em;
+    padding: 1em;
+    text-shadow: $selectedTextShadow;
+  }
+}

--- a/FE/src/components/SettingContent/CSVSetting/CSVExport/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/CSVExport/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import './csvExport.scss';
+import exportToCSV from '../../../../service/export';
+import ActionButton from '../../../Common/ActionButton';
+import { getTransactionCSV } from '../../../../api/csv';
+
+export default function CSVExport({ accountBookId }) {
+  const downloadCSV = async () => {
+    const response = await getTransactionCSV(accountBookId);
+    const csv = response.data;
+    exportToCSV(csv);
+  };
+
+  return (
+    <div className="csv__export__box">
+      <div className="csv__export__title">Export</div>
+      <ActionButton content="Export" action={downloadCSV} type="large" />
+    </div>
+  );
+}

--- a/FE/src/components/SettingContent/CSVSetting/CSVExport/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/CSVExport/index.tsx
@@ -15,7 +15,12 @@ export default function CSVExport({ accountBookId }) {
   return (
     <div className="csv__export__box">
       <div className="csv__export__title">Export</div>
-      <ActionButton content="Export" action={downloadCSV} type="large" />
+      <div className="csv__export__desc">
+        You can get all Transactions in this Account Book.
+      </div>
+      <div className="csv__export__btn">
+        <ActionButton content="Export" action={downloadCSV} type="general" />
+      </div>
     </div>
   );
 }

--- a/FE/src/components/SettingContent/CSVSetting/CSVImport/csvImport.scss
+++ b/FE/src/components/SettingContent/CSVSetting/CSVImport/csvImport.scss
@@ -5,29 +5,36 @@
   @include settingBox;
 
   .csv__import__title {
-    font-size: 1.5em;
-    padding: 1em;
-    text-shadow: $selectedTextShadow;
+    @include settingTitle;
   }
 
-  .csv-input {
-    border-radius: 1px solid $dark-border-color;
-    margin-bottom: 10px;
+  .csv__import__desc {
+    @include settingDesc;
   }
 
-  .csv__import__filebtn {
+  .csv__import__filebox {
     display: flex;
-    background-color: transparent;
-    flex-direction: column;
-  }
+    justify-content: center;
+    align-items: center;
 
-  .csv__import__input {
+    width: 30%;
+    border-radius: 6px;
     background-color: transparent;
-    color: $dark-emphasize-font-color;
   }
+  .csv__import__content {
+    display: flex;
+    justify-content: center;
+    gap: 5%;
 
-  .csv__import__filebtn {
-    background-color: transparent;
-    background-color: #219cf3;
+    .csv__import__btn {
+    }
+    .csv__import__input {
+      button {
+        background-color: transparent;
+      }
+
+      font-size: 1.5vh;
+      color: $dark-emphasize-font-color;
+    }
   }
 }

--- a/FE/src/components/SettingContent/CSVSetting/CSVImport/csvImport.scss
+++ b/FE/src/components/SettingContent/CSVSetting/CSVImport/csvImport.scss
@@ -1,0 +1,33 @@
+@use '../../../../styles/values'as *;
+@use '../../../../styles/mixins'as *;
+
+.csv__import__box {
+  @include settingBox;
+
+  .csv__import__title {
+    font-size: 1.5em;
+    padding: 1em;
+    text-shadow: $selectedTextShadow;
+  }
+
+  .csv-input {
+    border-radius: 1px solid $dark-border-color;
+    margin-bottom: 10px;
+  }
+
+  .csv__import__filebtn {
+    display: flex;
+    background-color: transparent;
+    flex-direction: column;
+  }
+
+  .csv__import__input {
+    background-color: transparent;
+    color: $dark-emphasize-font-color;
+  }
+
+  .csv__import__filebtn {
+    background-color: transparent;
+    background-color: #219cf3;
+  }
+}

--- a/FE/src/components/SettingContent/CSVSetting/CSVImport/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/CSVImport/index.tsx
@@ -22,13 +22,23 @@ export default function CSVImport(props) {
   return (
     <div className="csv__import__box">
       <div className="csv__import__title">Import</div>
-      <ActionButton content="Import" action={onClickHandler} type="large" />
-      <CSVReader
-        onFileLoaded={data => fileChangeHandler(data)}
-        cssInputClass="csv__import__input"
-        cssClass="csv__import__filebox"
-        cssLabelClass="csv__import__filebtn"
-      />
+      <div className="csv__import__desc">
+        Please, select '.csv' file and click Import Button
+      </div>
+      <div className="csv__import__content">
+        <CSVReader
+          onFileLoaded={data => fileChangeHandler(data)}
+          cssInputClass="csv__import__input"
+          cssClass="csv__import__filebox"
+        />
+        <div className="csv__import__btn">
+          <ActionButton
+            content="Import"
+            action={onClickHandler}
+            type="general"
+          />
+        </div>
+      </div>
     </div>
   );
 }

--- a/FE/src/components/SettingContent/CSVSetting/CSVImport/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/CSVImport/index.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+import CSVReader from 'react-csv-reader';
+import ActionButton from '../../../Common/ActionButton';
+import './csvImport.scss';
+import { postTransactionCSV } from '../../../../api/csv';
+
+export default function CSVImport(props) {
+  const [file, setFile] = useState('');
+
+  const onClickHandler = async event => {
+    if (file !== '') {
+      await postTransactionCSV(accountBookId, file);
+    }
+  };
+
+  const fileChangeHandler = data => {
+    const uploadFile = data;
+    setFile(uploadFile);
+  };
+
+  return (
+    <div className="csv__import__box">
+      <div className="csv__import__title">Import</div>
+      <ActionButton content="Import" action={onClickHandler} type="large" />
+      <CSVReader
+        onFileLoaded={data => fileChangeHandler(data)}
+        cssInputClass="csv__import__input"
+        cssClass="csv__import__filebox"
+        cssLabelClass="csv__import__filebtn"
+      />
+    </div>
+  );
+}

--- a/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
+++ b/FE/src/components/SettingContent/CSVSetting/csvSetting.scss
@@ -1,41 +1,6 @@
+@use '../../../styles/mixins'as *;
+@use '../../../styles/values'as *;
+
 .csv__setting__container {
-  color: white;
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-
-  .csv__export {
-    background: transparent;
-    height: 54px;
-    color: white;
-    border: 1px 0 0 10px #219cf3 solid;
-    box-shadow: none;
-    border-radius: 16px;
-    padding: 16px;
-    overflow: visible;
-    cursor: pointer;
-    text-shadow: 0 0 10px #219cf3, 0 0 10px #219cf3;
-  }
-
-  .csv__import__form {
-    display: flex;
-    flex-direction: column;
-
-    .csv-input {
-      margin-bottom: 10px;
-    }
-
-    .csv__import {
-      background: transparent;
-      color: white;
-      width: 216px;
-      border: 1px 0 0 10px #219cf3 solid;
-      box-shadow: none;
-      border-radius: 16px;
-      padding: 16px;
-      overflow: visible;
-      cursor: pointer;
-      text-shadow: 0 0 10px #219cf3, 0 0 10px #219cf3;
-    }
-  }
+  @include settingContainer;
 }

--- a/FE/src/components/SettingContent/CSVSetting/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/index.tsx
@@ -1,44 +1,18 @@
 import React, { useState } from 'react';
 import { useHistory } from 'react-router-dom';
-import CSVReader from 'react-csv-reader';
 
 import './csvSetting.scss';
-import { getTransactionCSV, postTransactionCSV } from '../../../api/csv';
-import exportToCSV from '../../../service/export';
+
+import CSVImport from './CSVImport';
+import CSVExport from './CSVExport';
 
 export default function CSVSetting(props) {
   const accountBookId = useHistory().location.state.id;
 
-  const downloadCSV = async () => {
-    const response = await getTransactionCSV(accountBookId);
-    const csv = response.data;
-    exportToCSV(csv);
-  };
-
-  const [file, setFile] = useState('');
-
-  const fileChangeHandler = data => {
-    const uploadFile = data;
-    setFile(uploadFile);
-  };
-
-  const onClickHandler = async event => {
-    if (file !== '') {
-      await postTransactionCSV(accountBookId, file);
-    }
-  };
-
   return (
     <div className="csv__setting__container">
-      <button className="csv__export" onClick={downloadCSV}>
-        거래내역 CSV File로 다운받기
-      </button>
-      <div className="csv__import__form">
-        <CSVReader onFileLoaded={data => fileChangeHandler(data)} />
-        <button className="csv__import" onClick={onClickHandler}>
-          거래내역 CSV File로 추가하기
-        </button>
-      </div>
+      <CSVImport />
+      <CSVExport accountBookId={accountBookId} />
     </div>
   );
 }

--- a/FE/src/components/SettingContent/CalendarSetting/DayRadioButton/dayRadioButton.scss
+++ b/FE/src/components/SettingContent/CalendarSetting/DayRadioButton/dayRadioButton.scss
@@ -2,10 +2,9 @@
   justify-content: center;
   width: 100%;
   display: flex;
-  padding: 0 2em;
-  gap: 9.5%;
+  gap: 7%;
   position: relative;
-
+  font-size: 2vh;
   label {
     position: relative;
   }

--- a/FE/src/components/SettingContent/CalendarSetting/WeekHeader/index.tsx
+++ b/FE/src/components/SettingContent/CalendarSetting/WeekHeader/index.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import CalendarHeader from '../../../Calendar/CalendarHeader';
 
+import './weekHeader.scss';
+
 export default function WeekHeader({ startDay }) {
   return (
     <table className="start__day__header">

--- a/FE/src/components/SettingContent/CalendarSetting/WeekHeader/weekHeader.scss
+++ b/FE/src/components/SettingContent/CalendarSetting/WeekHeader/weekHeader.scss
@@ -1,0 +1,25 @@
+@use '../../../../styles/values' as *;
+
+.start__day__header {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  font-size: 1.5vw;
+  margin-top: 3em;
+  th {
+    color: $white;
+
+    margin-left: 10px;
+    &.sunday {
+      color: $spending-color;
+    }
+
+    &::before {
+      content: '|';
+      padding: 0 1em;
+    }
+    &:first-child::before {
+      content: none;
+    }
+  }
+}

--- a/FE/src/components/SettingContent/CalendarSetting/calendarSetting.scss
+++ b/FE/src/components/SettingContent/CalendarSetting/calendarSetting.scss
@@ -2,43 +2,18 @@
 @use '../../../styles/mixins.scss' as *;
 .calendar__setting__container {
   @include settingContainer;
-  transform: translateY(-10%);
+
+  .calendar__setting__title {
+    @include settingTitle;
+  }
+  .calendar__setting__desc {
+    @include settingDesc;
+  }
+
   .calendar__setting__startday {
     @include settingBox;
     position: relative;
     background-color: transparent;
-
-    .calendar__setting__title {
-      text-align: center;
-      line-height: 3.5em;
-      font-size: 2em;
-      text-shadow: $selectedTextShadow;
-    }
-
-    .start__day__header {
-      position: absolute;
-      width: 100%;
-      display: flex;
-      justify-content: center;
-      font-size: 1.5vw;
-      margin-top: 3em;
-      th {
-        color: $white;
-
-        margin-left: 10px;
-        &.sunday {
-          color: $spending-color;
-        }
-
-        &::before {
-          content: '|';
-          padding: 0 1em;
-        }
-        &:first-child::before {
-          content: none;
-        }
-      }
-    }
 
     .calendar__save__btn {
       position: absolute;

--- a/FE/src/components/SettingContent/CalendarSetting/index.tsx
+++ b/FE/src/components/SettingContent/CalendarSetting/index.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 
-
 import { useAccountBookData } from '../../../store/AccountBook/accountBookInfoHook';
 
 import DayRadioButton from './DayRadioButton';
@@ -16,11 +15,9 @@ export default function CalendarSetting({
   setUpdateData,
   setSaveAction,
 }) {
-
   const start = useAccountBookData(store => store.accountBook.startday);
 
   const [startDay, setStartDay] = useState('');
-
 
   const onClickSaveBtn = () => {
     setSaveModal(() => true);
@@ -38,7 +35,9 @@ export default function CalendarSetting({
     <div className="calendar__setting__container">
       <div className="calendar__setting__startday">
         <div className="calendar__setting__title">Start Day</div>
-
+        <div className="calendar__setting__desc">
+          You can select start day of Calendar
+        </div>
         <DayRadioButton startDay={startDay} setStartDay={setStartDay} />
         <WeekHeader startDay={startDay} />
         <div className="calendar__save__btn">

--- a/FE/src/components/SettingContent/CategorySetting/CategoryModal/categoryModal.scss
+++ b/FE/src/components/SettingContent/CategorySetting/CategoryModal/categoryModal.scss
@@ -2,10 +2,10 @@
 @use '../../../../styles/mixins.scss' as *;
 
 .category__modal__overlay {
-  position: absolute;
+  position: fixed;
   width: 100%;
   height: 100%;
-  transform: translateY(-10%);
+
   background-color: $modal-background;
   z-index: 2;
   display: flex;

--- a/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
+++ b/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
@@ -18,11 +18,9 @@
 
 @mixin categorySettingBox {
   @include settingBox;
-  padding: 1em 2em;
+
   .category__title {
-    font-size: 1.5em;
-    padding: 1em;
-    text-shadow: $selectedTextShadow;
+    @include settingTitle;
   }
   .category__list {
     display: flex;

--- a/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
+++ b/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
@@ -2,9 +2,11 @@
 @use '../../../styles/mixins.scss' as *;
 
 @mixin categoryUnit {
-  padding: 0.5em 1.5em;
+  height: 5vh;
+  line-height: 5vh;
   border: 1px solid $dark-border-color;
   border-radius: 20px;
+  text-align: center;
   cursor: pointer;
   &:hover {
     background-color: $light-black;
@@ -27,12 +29,14 @@
 
     .category__unit {
       @include categoryUnit;
+      width: 10vw;
     }
 
     .category__unit__add {
       @include categoryUnit;
       .fas.fa-plus-circle {
         color: $white;
+        width: 7vw;
       }
     }
   }

--- a/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
+++ b/FE/src/components/SettingContent/CategorySetting/categorySetting.scss
@@ -1,5 +1,6 @@
 @use '../../../styles/values.scss' as *;
 @use '../../../styles/mixins.scss' as *;
+@use '../../../styles/mediaQuery.scss' as *;
 
 @mixin categoryUnit {
   height: 5vh;
@@ -7,6 +8,7 @@
   border: 1px solid $dark-border-color;
   border-radius: 20px;
   text-align: center;
+  font-size: 1.5vh;
   cursor: pointer;
   &:hover {
     background-color: $light-black;
@@ -16,6 +18,7 @@
 
 @mixin categorySettingBox {
   @include settingBox;
+  padding: 1em 2em;
   .category__title {
     font-size: 1.5em;
     padding: 1em;
@@ -29,14 +32,14 @@
 
     .category__unit {
       @include categoryUnit;
-      width: 10vw;
+      width: 8vw;
     }
 
     .category__unit__add {
       @include categoryUnit;
       .fas.fa-plus-circle {
         color: $white;
-        width: 7vw;
+        width: 5vw;
       }
     }
   }
@@ -50,5 +53,12 @@
   }
   .spending__category__setting {
     @include categorySettingBox;
+  }
+
+  @include mobile {
+    .income__category__setting,
+    .spending__category__setting {
+      width: 80%;
+    }
   }
 }

--- a/FE/src/components/SettingContent/UserSetting/InviteCode/index.tsx
+++ b/FE/src/components/SettingContent/UserSetting/InviteCode/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import ActionButton from '../../../Common/ActionButton';
 import { useAccountBookData } from '../../../../store/AccountBook/accountBookInfoHook';
@@ -7,14 +7,25 @@ import './inviteCode.scss';
 
 export default function InviteCode(props) {
   const accountBookId = useAccountBookData(store => store.accountBook._id);
-  const [codeVisible, setCodeVisible] = useState(true);
+  const [codeVisible, setCodeVisible] = useState(false);
   const [codeContent, setCodeContet] = useState('');
+  const [clipBoardMessage, setClipBoardMessage] = useState(false);
 
   const onClickGetCode = async () => {
     const res = await getInviteCode({ accountBookId });
 
     setCodeContet(res.data.code);
     setCodeVisible(() => true);
+  };
+
+  const onClicClipBoard = () => {
+    const oneTimeDom = document.createElement('textarea');
+    oneTimeDom.value = codeContent;
+    document.body.appendChild(oneTimeDom);
+    oneTimeDom.select();
+    document.execCommand('copy');
+    document.body.removeChild(oneTimeDom);
+    setClipBoardMessage(true);
   };
 
   return (
@@ -34,9 +45,15 @@ export default function InviteCode(props) {
         </div>
 
         {codeVisible && (
-          <div className="invite__code__content">{codeContent}</div>
+          <div className="content__and__clipboard">
+            <div className="invite__code">{codeContent}</div>
+            <i className="far fa-clipboard" onClick={onClicClipBoard} />
+          </div>
         )}
       </div>
+      {clipBoardMessage && (
+        <div className="clip__board__message">클립보드에 복사되었습니다.</div>
+      )}
     </div>
   );
 }

--- a/FE/src/components/SettingContent/UserSetting/InviteCode/index.tsx
+++ b/FE/src/components/SettingContent/UserSetting/InviteCode/index.tsx
@@ -19,17 +19,24 @@ export default function InviteCode(props) {
 
   return (
     <div className="invite__code__box">
-      <div className="get__code__button">
-        <ActionButton
-          type="large"
-          content="Invite Code"
-          action={onClickGetCode}
-        />
+      <div className="invite__code__title">Invite Code</div>
+      <div className="invite__code__desc">
+        You can get invite code to invite someone.
       </div>
 
-      {codeVisible && (
-        <div className="invite__code__content">{codeContent}</div>
-      )}
+      <div className="invite__code__content">
+        <div className="get__code__button">
+          <ActionButton
+            type="large"
+            content="Invite Code"
+            action={onClickGetCode}
+          />
+        </div>
+
+        {codeVisible && (
+          <div className="invite__code__content">{codeContent}</div>
+        )}
+      </div>
     </div>
   );
 }

--- a/FE/src/components/SettingContent/UserSetting/InviteCode/inviteCode.scss
+++ b/FE/src/components/SettingContent/UserSetting/InviteCode/inviteCode.scss
@@ -3,22 +3,29 @@
 
 .invite__code__box {
   @include settingBox;
-  position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
 
-  .get__code__button {
-    position: absolute;
-    top: 5%;
+  .invite__code__title {
+    @include settingTitle;
   }
+
+  .invite__code__desc {
+    @include settingDesc;
+  }
+
   .invite__code__content {
-    position: absolute;
-    font-size: 3vh;
-    padding-bottom: 1em;
-    border-bottom: 1px solid $dark-emphasize-font-color;
-    &.hidden {
-      display: none;
+    display: flex;
+    justify-content: center;
+    gap: 15%;
+
+    .get__code__button {
+      font-size: 1.5vh;
+    }
+    .invite__code__content {
+      padding-bottom: 1em;
+      border-bottom: 1px solid $dark-emphasize-font-color;
+      &.hidden {
+        display: none;
+      }
     }
   }
 }

--- a/FE/src/components/SettingContent/UserSetting/InviteCode/inviteCode.scss
+++ b/FE/src/components/SettingContent/UserSetting/InviteCode/inviteCode.scss
@@ -15,17 +15,31 @@
   .invite__code__content {
     display: flex;
     justify-content: center;
+    align-items: center;
     gap: 15%;
 
     .get__code__button {
       font-size: 1.5vh;
     }
-    .invite__code__content {
-      padding-bottom: 1em;
-      border-bottom: 1px solid $dark-emphasize-font-color;
-      &.hidden {
-        display: none;
+
+    .content__and__clipboard {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      .invite__code {
+        padding-bottom: 1.5vh;
+        border-bottom: 1px solid $dark-emphasize-font-color;
+      }
+      .far.fa-clipboard {
+        margin-left: 15px;
+        font-size: 3vh;
+        cursor: pointer;
       }
     }
+  }
+  .clip__board__message {
+    display: flex;
+    justify-content: center;
+    padding: 3vh 0;
   }
 }

--- a/FE/src/components/SettingContent/UserSetting/UserList/index.tsx
+++ b/FE/src/components/SettingContent/UserSetting/UserList/index.tsx
@@ -16,14 +16,22 @@ export default function UserList(props) {
   };
   return (
     <div className="user__list__box">
+      <div className="user__list__title">User List</div>
+      <div className="user__list__desc">
+        You can see users in this Account Book
+      </div>
       <div className="drop__btn">
-        <ActionButton content="탈퇴하기" type="large" action={onClickDropBtn} />
+        <ActionButton
+          content="탈퇴하기"
+          type="general"
+          action={onClickDropBtn}
+        />
       </div>
       {users &&
         users.map(user => (
           <div className="user__info">
             <img src={user.profile} className="profile__image" />
-            <div>{user.name}</div>
+            <div className="user__name">{user.name}</div>
           </div>
         ))}
     </div>

--- a/FE/src/components/SettingContent/UserSetting/UserList/userList.scss
+++ b/FE/src/components/SettingContent/UserSetting/UserList/userList.scss
@@ -7,12 +7,19 @@
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
+
+  .user__list__title {
+    @include settingTitle;
+  }
+  .user__list__desc {
+    @include settingDesc;
+  }
   .user__info {
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    width: 15%;
+
     .profile__image {
       width: 40px;
       height: 40px;

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -16,7 +16,7 @@ import './settingPage.scss';
 export default function SettingPage() {
   useLoginCheck();
 
-  const [settingType, setSettingType] = useState('user');
+  const [settingType, setSettingType] = useState('category');
   const [saveModal, setSaveModal] = useState(false);
   const [saveAction, setSaveAction] = useState(null);
   const [updateData, setUpdateData] = useState({});

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -16,7 +16,7 @@ import './settingPage.scss';
 export default function SettingPage() {
   useLoginCheck();
 
-  const [settingType, setSettingType] = useState('csv');
+  const [settingType, setSettingType] = useState('calendar');
   const [saveModal, setSaveModal] = useState(false);
   const [saveAction, setSaveAction] = useState(null);
   const [updateData, setUpdateData] = useState({});

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -16,7 +16,7 @@ import './settingPage.scss';
 export default function SettingPage() {
   useLoginCheck();
 
-  const [settingType, setSettingType] = useState('calendar');
+  const [settingType, setSettingType] = useState('user');
   const [saveModal, setSaveModal] = useState(false);
   const [saveAction, setSaveAction] = useState(null);
   const [updateData, setUpdateData] = useState({});

--- a/FE/src/pages/SettingPage/index.tsx
+++ b/FE/src/pages/SettingPage/index.tsx
@@ -16,7 +16,7 @@ import './settingPage.scss';
 export default function SettingPage() {
   useLoginCheck();
 
-  const [settingType, setSettingType] = useState('category');
+  const [settingType, setSettingType] = useState('csv');
   const [saveModal, setSaveModal] = useState(false);
   const [saveAction, setSaveAction] = useState(null);
   const [updateData, setUpdateData] = useState({});

--- a/FE/src/styles/mixins.scss
+++ b/FE/src/styles/mixins.scss
@@ -62,6 +62,23 @@
 
 // setting tab
 
+@mixin settingTitle {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  font-size: 3vh;
+  padding: 3.5vh 0;
+  text-shadow: $selectedTextShadow;
+}
+
+@mixin settingDesc {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  font-size: 2vh;
+  padding: 3vh 0;
+}
+
 @mixin settingContainer {
   width: 100%;
   height: 100%;
@@ -78,6 +95,7 @@
   height: 40%;
   border: 1px solid $dark-border-color;
   border-radius: 6px;
+  padding: 1.5vw;
 }
 
 // header

--- a/FE/src/styles/mixins.scss
+++ b/FE/src/styles/mixins.scss
@@ -76,7 +76,7 @@
   display: flex;
   justify-content: center;
   font-size: 2vh;
-  padding: 3vh 0;
+  padding-bottom: 3vh;
 }
 
 @mixin settingContainer {

--- a/FE/src/styles/mixins.scss
+++ b/FE/src/styles/mixins.scss
@@ -79,3 +79,45 @@
   border: 1px solid $dark-border-color;
   border-radius: 6px;
 }
+
+// header
+@mixin headerSetting {
+  position: relative;
+  background-color: $dark-background-color;
+  width: 100%;
+
+  padding-top: 2.5%;
+  z-index: 2;
+}
+
+@mixin headerButtons {
+  display: flex;
+  justify-content: center;
+  gap: 3em;
+  position: relative;
+}
+
+@mixin headerNavigationButtons($type) {
+  @include buttonDefaultSetting;
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+
+  text-align: center;
+  line-height: 1.5em;
+  @if $type == left {
+    left: 5%;
+  } @else {
+    right: 5%;
+  }
+  height: 1.5em;
+  background-color: transparent;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5em;
+  font-size: 1.5em;
+
+  text-shadow: $selectedTextShadow;
+  color: $dark-emphasize-font-color;
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] setting page 공통 디자인 mixin으로 분리 후 적용
- setting page에는 4가지 탭이 있는데, 모두 디자인의 통일성을 주기 위해 공통 디자인 요소를 분리하였습니다.
- 전체 컨테이너부터, setting box, title, desc로 분리하여 각각 공통 mixin값을 사용하도록 하였습니다.
- [x] 반응형 대비
- 모바일 크기로 줄였을 때 어느정도 레이아웃이 잡히도록 조금씩 수정하는 중입니다.
- 모바일 버전의 구체적인 디자인을 정한 것이 없어서 임의로 아이템 크기 또는 배치등만 일부 수정중입니다.
- [x] Invite Code 클립보드 복사기능 구현
- 돔조작을 직접하는 것처럼 보이지만, 복사하고자 하는 text를 일회성으로 보관하기 위해 만들었다가 삭제해줍니다.
- Invite Code가 해쉬값이므로, 간편하게 클릭하여 복사한다음 사용할 수 있도록 하였습니다. (UX고려)
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
