### PR TITLE
[FE] 거래내역 drag and drop 및 거래내역 추가 모달 수정

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -1096,6 +1096,94 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@emotion/cache": {
+      "version": "10.0.29",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+      "requires": {
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
+      }
+    },
+    "@emotion/core": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.1.1.tgz",
+      "integrity": "sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
+      }
+    },
+    "@emotion/css": {
+      "version": "10.0.27",
+      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
+      "requires": {
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
+      }
+    },
+    "@emotion/hash": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+    },
+    "@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+    },
+    "@emotion/serialize": {
+      "version": "0.11.16",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+      "requires": {
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
+        "csstype": "^2.5.7"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+        }
+      }
+    },
+    "@emotion/sheet": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+    },
+    "@emotion/stylis": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+    },
+    "@emotion/unitless": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+    },
+    "@emotion/utils": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+    },
+    "@emotion/weak-memoize": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+    },
     "@eslint/eslintrc": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
@@ -1520,6 +1608,26 @@
         "@types/history": "*",
         "@types/react": "*",
         "@types/react-router": "*"
+      }
+    },
+    "@types/react-select": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/@types/react-select/-/react-select-3.0.28.tgz",
+      "integrity": "sha512-Gfg3a/EPLyUQkfezcCQkmLW1Vz6+ziclJhn8dpBUEYJF3IUoxS81ToAi3ky2xtnAyk2wJFMXLvE73KiUd56yTA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "@types/react-transition-group": "*"
+      }
+    },
+    "@types/react-transition-group": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.0.tgz",
+      "integrity": "sha512-/QfLHGpu+2fQOqQaXh8MG9q03bFENooTb/it4jr5kKaZlDQfWvjqWZg48AwzPVMBHlRuTRAY7hRHCEOXz5kV6w==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/sass": {
@@ -2433,6 +2541,63 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-plugin-emotion": {
+      "version": "10.0.33",
+      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
+        "babel-plugin-macros": "^2.0.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^1.0.5",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "babel-plugin-macros": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+          "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.1.0",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.7.2"
+          }
+        },
+        "parse-json": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+        }
+      }
+    },
     "babel-plugin-styled-components": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.11.1.tgz",
@@ -2448,8 +2613,7 @@
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-      "dev": true
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
     },
     "bail": {
       "version": "1.0.5",
@@ -3735,8 +3899,7 @@
     "csstype": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.5.tgz",
-      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ==",
-      "dev": true
+      "integrity": "sha512-uVDi8LpBUKQj6sdxNaTetL6FpeCqTjOvAQuQUa/qAqq8oOd4ivkbhgnqayl0dnPal8Tb/yB1tF+gOvCBiicaiQ=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -4017,6 +4180,15 @@
       "dev": true,
       "requires": {
         "utila": "~0.4"
+      }
+    },
+    "dom-helpers": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.0.tgz",
+      "integrity": "sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==",
+      "requires": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "dom-serializer": {
@@ -5167,6 +5339,11 @@
         "make-dir": "^2.0.0",
         "pkg-dir": "^3.0.0"
       }
+    },
+    "find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
     },
     "find-up": {
       "version": "3.0.0",
@@ -6976,6 +7153,11 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
+    },
     "memory-fs": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
@@ -8637,6 +8819,14 @@
         "scheduler": "^0.20.1"
       }
     },
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -8704,6 +8894,32 @@
         "react-router": "5.2.0",
         "tiny-invariant": "^1.0.2",
         "tiny-warning": "^1.0.0"
+      }
+    },
+    "react-select": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.1.tgz",
+      "integrity": "sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
+      }
+    },
+    "react-transition-group": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+      "integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
       }
     },
     "read-pkg": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -22,6 +22,7 @@
     "react-csv-reader": "^3.1.1",
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
+    "react-select": "^3.1.1",
     "sass": "^1.29.0",
     "url-loader": "^4.1.1",
     "uuid": "^8.3.1"
@@ -36,6 +37,7 @@
     "@types/react": "^16.9.56",
     "@types/react-dom": "^16.9.9",
     "@types/react-router-dom": "^5.1.6",
+    "@types/react-select": "^3.0.28",
     "@types/sass": "^1.16.0",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.0.1",

--- a/FE/src/app.scss
+++ b/FE/src/app.scss
@@ -26,3 +26,9 @@ body {
 a {
   text-decoration: none;
 }
+
+ul {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+}

--- a/FE/src/components/transaction/TransactionAddModal/CategoryInput/index.scss
+++ b/FE/src/components/transaction/TransactionAddModal/CategoryInput/index.scss
@@ -21,24 +21,18 @@
     cursor: pointer;
   }
 
-  input[type='radio'][name='category'] + span:hover {
-    background: $transaction-category-hover-color;
+  input[type='radio'][name='type'][value='수입']:checked + span,
+  input[type='radio'][name='type'][value='수입'] + span:hover,
+  input[type='radio'][name='category'][data-type='수입']:checked + span,
+  input[type='radio'][name='category'][data-type='수입'] + span:hover {
+    background: $transaction-modal-income-category-color;
     color: #fff;
   }
 
-  input[type='radio'][name='category']:checked + span {
-    border: 1px solid $transaction-category-hover-color;
-    background: $transaction-selected-item-color;
-    color: #fff;
-  }
-
-  input[type='radio'][name='type'] + span:hover {
-    background: $transaction-modal-spending-category-color;
-    color: #fff;
-  }
-
-  input[type='radio'][name='type']:checked + span {
-    border: 1px solid $transaction-modal-spending-category-color;
+  input[type='radio'][name='type'][value='지출']:checked + span,
+  input[type='radio'][name='type'][value='지출'] + span:hover,
+  input[type='radio'][name='category'][data-type='지출']:checked + span,
+  input[type='radio'][name='category'][data-type='지출'] + span:hover {
     background: $transaction-modal-spending-category-color;
     color: #fff;
   }

--- a/FE/src/components/transaction/TransactionAddModal/DateInput/index.scss
+++ b/FE/src/components/transaction/TransactionAddModal/DateInput/index.scss
@@ -4,18 +4,21 @@ select {
   -moz-appearance: none;
   -webkit-appearance: none;
   appearance: none;
-  @include input-form;
 }
 
 .row__item {
   margin-right: 20px;
   font-size: 18px;
+  display: flex;
+  align-items: center;
 
-  select {
+  .select {
     font-size: inherit;
     line-height: 1.5;
     padding: 0.3em 1em 0.3em 0.7em;
     border: none;
     border-bottom: 2px solid;
+    @include input-form;
+    overflow: auto;
   }
 }

--- a/FE/src/components/transaction/TransactionAddModal/DateInput/index.tsx
+++ b/FE/src/components/transaction/TransactionAddModal/DateInput/index.tsx
@@ -1,4 +1,5 @@
 import React, { ChangeEvent } from 'react';
+import Select, { ValueType } from 'react-select';
 
 import calculateDate from '../../../../util/calculateDate';
 import { useTransactionAddModalData } from '../../../../store/TransactionFormModal/TransactionFormModalHook';
@@ -11,23 +12,48 @@ const DateInput = () => {
     setInput: store.setInput,
   }));
 
-  const onYearChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    if (e.target) {
-      const targetElement = e.target as HTMLSelectElement;
-      setInput({ ...input, year: targetElement.value });
-    }
+  const selectStyles = {
+    option: (provided, state) => ({
+      ...provided,
+      color: 'black',
+    }),
+    control: provided => ({
+      ...provided,
+      width: '80px',
+      marginRight: '5px',
+    }),
+    dropdownIndicator: provided => ({
+      width: '20px',
+    }),
   };
-  const onMonthChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    if (e.target) {
-      const targetElement = e.target as HTMLSelectElement;
-      setInput({ ...input, month: targetElement.value });
-    }
-  };
-  const onDayChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    if (e.target) {
-      const targetElement = e.target as HTMLSelectElement;
-      setInput({ ...input, day: targetElement.value });
-    }
+
+  const yearOptions = Array.from(
+    { length: 61 },
+    (_, i) => i + +(new Date().getFullYear() - 30),
+  ).map(year => ({
+    value: year,
+    label: year,
+  }));
+
+  const monthOptions = Array.from({ length: 12 }, (_, i) => i + 1).map(
+    month => ({
+      value: month,
+      label: month,
+    }),
+  );
+
+  const dayOptions = Array.from(
+    {
+      length: calculateDate.getDaysInMonth(+input.year, +(input.month + 1)),
+    },
+    (_, i) => i + 1,
+  ).map(day => ({
+    value: day,
+    label: day,
+  }));
+
+  const onSelectChange = type => item => {
+    setInput({ ...input, [type]: item.value });
   };
 
   return (
@@ -35,52 +61,30 @@ const DateInput = () => {
       <div className="indicator">날짜</div>
       <div className="row">
         <div className="row__item">
-          <select
-            name="year"
-            defaultValue={+input.year}
-            onChange={onYearChange}
-          >
-            {Array.from(
-              { length: 61 },
-              (_, i) => i + +(new Date().getFullYear() - 30),
-            ).map(item => (
-              <option value={item} key={item}>
-                {item}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={yearOptions.find(({ value }) => value === +input.year)}
+            onChange={onSelectChange('year')}
+            options={yearOptions}
+            styles={selectStyles}
+          />
           년
         </div>
         <div className="row__item">
-          <select
-            name="month"
-            defaultValue={+input.month}
-            onChange={onMonthChange}
-          >
-            {Array.from({ length: 12 }, (_, i) => i + 1).map(item => (
-              <option value={item} key={item}>
-                {item}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={monthOptions.find(({ value }) => value === +input.month)}
+            onChange={onSelectChange('month')}
+            options={monthOptions}
+            styles={selectStyles}
+          />
           월
         </div>
         <div className="row__item">
-          <select name="date" defaultValue={+input.day} onChange={onDayChange}>
-            {Array.from(
-              {
-                length: calculateDate.getDaysInMonth(
-                  +input.year,
-                  +(input.month + 1),
-                ),
-              },
-              (_, i) => i + 1,
-            ).map(item => (
-              <option value={item} key={item}>
-                {item}
-              </option>
-            ))}
-          </select>
+          <Select
+            value={dayOptions.find(({ value }) => value === +input.day)}
+            onChange={onSelectChange('day')}
+            options={dayOptions}
+            styles={selectStyles}
+          />
           일
         </div>
       </div>

--- a/FE/src/components/transaction/TransactionAddModal/PaymentInput/index.scss
+++ b/FE/src/components/transaction/TransactionAddModal/PaymentInput/index.scss
@@ -20,7 +20,7 @@
         border-radius: 16px;
 
         color: $light-black;
-        background-color: $little-white;
+        background-color: $light-grey;
         border: 1px solid $dark-border-color;
         display: flex;
         flex-direction: column;

--- a/FE/src/components/transaction/TransactionAddModal/PaymentInput/index.tsx
+++ b/FE/src/components/transaction/TransactionAddModal/PaymentInput/index.tsx
@@ -37,7 +37,14 @@ const PaymentInput = ({ paymentPool }) => {
                 onChange={onPaymentChange}
                 checked={name === input.payment?.name}
               />
-              <div className="payment__card__view">
+              <div
+                className="payment__card__view"
+                style={
+                  name === input.payment?.name
+                    ? { backgroundColor: color }
+                    : undefined
+                }
+              >
                 <div className="payment__card__title">{name}</div>
                 <div className="payment__card__description">{desc}</div>
               </div>

--- a/FE/src/components/transaction/TransactionAddModal/PriceInput/index.scss
+++ b/FE/src/components/transaction/TransactionAddModal/PriceInput/index.scss
@@ -1,7 +1,22 @@
 @use '../../../../styles/mixins.scss' as *;
+@use '../../../../styles/values.scss' as *;
 
-.price__input {
+.price__input__container {
+  .price__input {
+    position: relative;
+    label {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      left: 0;
+      top: 0;
+      padding: 0.5em 1em;
+      color: $black;
+      background-color: $white;
+    }
+  }
   input {
     @include input-form;
+    color: $transparent-color;
   }
 }

--- a/FE/src/components/transaction/TransactionAddModal/PriceInput/index.tsx
+++ b/FE/src/components/transaction/TransactionAddModal/PriceInput/index.tsx
@@ -1,10 +1,13 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useRef } from 'react';
 
 import { useTransactionAddModalData } from '../../../../store/TransactionFormModal/TransactionFormModalHook';
+import CommaMaker from '../../../../util/commaForMoney';
 
 import './index.scss';
 
 const PriceInput = () => {
+  const inputLabel = useRef(null);
+
   const { input, setInput } = useTransactionAddModalData(store => ({
     input: store.input,
     setInput: store.setInput,
@@ -14,21 +17,26 @@ const PriceInput = () => {
     if (e.target) {
       const targetElement = e.target as HTMLInputElement;
       setInput({ ...input, cost: +targetElement.value });
+      inputLabel.current.textContent = `₩ ${CommaMaker(+targetElement.value)}`;
+      console.log(inputLabel.current);
     }
   };
   return (
-    <div className="item price__input">
+    <div className="item price__input__container">
       <div className="indicator">금액</div>
-      <label>
+      <div className="price__input">
+        <label ref={inputLabel} htmlFor="price__input">
+          ₩ 0
+        </label>
         <input
+          id="price__input"
           type="number"
           name="price"
           onChange={onPriceChange}
           min="1"
-          placeholder="0"
           value={!!input.cost && input.cost}
         />
-      </label>
+      </div>
     </div>
   );
 };

--- a/FE/src/components/transaction/list/TransactionItem/index.scss
+++ b/FE/src/components/transaction/list/TransactionItem/index.scss
@@ -95,6 +95,29 @@
   }
 }
 
+.on__dragged__in {
+  border-radius: 10px;
+  box-shadow: $dragboxShadow;
+}
+
+.on__drag {
+  animation-name: air;
+  animation-duration: 1s;
+  animation-iteration-count: infinite;
+}
+
+@keyframes air {
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(5px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
 @keyframes button__in {
   0% {
     opacity: 0;

--- a/FE/src/components/transaction/list/TransactionItem/index.tsx
+++ b/FE/src/components/transaction/list/TransactionItem/index.tsx
@@ -15,6 +15,8 @@ const TransactionItem = ({
   payment,
   cost,
   type,
+  setDraggedItem,
+  dragObject,
 }: iTransactionItem) => {
   const [buttonReveal, setButtonReveal] = useState('');
 
@@ -28,8 +30,11 @@ const TransactionItem = ({
 
   const accountBookId = useHistory().location.state.id;
 
-  const deleteTransactionInStore = useAccountBookData(
-    store => store.deleteTransaction,
+  const { deleteTransactionInStore, getTransactionById } = useAccountBookData(
+    store => ({
+      deleteTransactionInStore: store.deleteTransaction,
+      getTransactionById: store.getTransactionById,
+    }),
   );
 
   const onTransactionClicked = () => {
@@ -72,8 +77,29 @@ const TransactionItem = ({
     }
   };
 
+  const onDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    console.log('on drag start');
+    e.target.classList.add('on__drag');
+
+    e.dataTransfer.setData('transactionId', transactionId);
+    const movedTransaction = getTransactionById(transactionId);
+
+    setDraggedItem(movedTransaction);
+    e.dataTransfer.dropEffect = 'move';
+  };
+
+  const onDragEnd = (e: React.DragEvent<HTMLDivElement>) => {
+    e.target.classList.remove('on__drag');
+  };
+
   return (
-    <div className="transaction__item" onClick={onTransactionClicked}>
+    <div
+      className={`transaction__item${dragObject ? ' on__dragged__in' : ''}`}
+      onClick={onTransactionClicked}
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+    >
       <div className="transaction__item__category">
         <span>{category.name}</span>
       </div>

--- a/FE/src/components/transaction/list/TransactionItem/index.tsx
+++ b/FE/src/components/transaction/list/TransactionItem/index.tsx
@@ -17,6 +17,7 @@ const TransactionItem = ({
   type,
   setDraggedItem,
   dragObject,
+  setDraggedInDate,
 }: iTransactionItem) => {
   const [buttonReveal, setButtonReveal] = useState('');
 
@@ -78,18 +79,20 @@ const TransactionItem = ({
   };
 
   const onDragStart = (e: React.DragEvent<HTMLDivElement>) => {
-    console.log('on drag start');
     e.target.classList.add('on__drag');
 
     e.dataTransfer.setData('transactionId', transactionId);
     const movedTransaction = getTransactionById(transactionId);
 
     setDraggedItem(movedTransaction);
-    e.dataTransfer.dropEffect = 'move';
   };
 
   const onDragEnd = (e: React.DragEvent<HTMLDivElement>) => {
     e.target.classList.remove('on__drag');
+    console.log('on end', e.dataTransfer.dropEffect);
+    setTimeout(() => {
+      setDraggedInDate('');
+    }, 50);
   };
 
   return (

--- a/FE/src/components/transaction/list/TransactionsOfOneDay/index.scss
+++ b/FE/src/components/transaction/list/TransactionsOfOneDay/index.scss
@@ -22,9 +22,4 @@
   // margin: 3em 1em;
   color: $dark-emphasize-font-color;
   text-shadow: $selectedTextShadow;
-  border: 1px solid white;
-}
-
-.transactions__oneday__container {
-  border: 1px solid white;
 }

--- a/FE/src/components/transaction/list/TransactionsOfOneDay/index.scss
+++ b/FE/src/components/transaction/list/TransactionsOfOneDay/index.scss
@@ -11,10 +11,20 @@
   padding: 10px 10px;
 }
 
+.transactions__oneday__day__draggedIn {
+  box-shadow: $selectedTextShadow;
+}
+
 .transactions__oneday__daybar {
   width: 100%;
   height: 30px;
-  padding: 0.5em 1em;
+  margin: 0.5em 1em;
+  // margin: 3em 1em;
   color: $dark-emphasize-font-color;
   text-shadow: $selectedTextShadow;
+  border: 1px solid white;
+}
+
+.transactions__oneday__container {
+  border: 1px solid white;
 }

--- a/FE/src/components/transaction/list/TransactionsOfOneDay/index.tsx
+++ b/FE/src/components/transaction/list/TransactionsOfOneDay/index.tsx
@@ -63,7 +63,6 @@ const TransactionsOfOneDay = ({
         }`}
         onDrop={onDrop}
         onDragOver={onDragOver}
-        onDragLeave={onDragLeave}
       >
         <label className="transactions__oneday__daybar">{date}일</label>
         <ul className="transactions__oneday__container">

--- a/FE/src/components/transaction/list/TransactionsOfOneDay/index.tsx
+++ b/FE/src/components/transaction/list/TransactionsOfOneDay/index.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import './index.scss';
 
 import { useHistory } from 'react-router-dom';
@@ -13,8 +13,9 @@ const TransactionsOfOneDay = ({
   transactions,
   draggedItem,
   setDraggedItem,
+  draggedInDate,
+  setDraggedInDate,
 }: iTransactionsOfOneDay) => {
-  const [draggedIn, setDraggedIn] = useState(false);
   const accountBookId = useHistory().location.state.id;
 
   const { getTransactionById, updateTransactionInStore } = useAccountBookData(
@@ -27,16 +28,7 @@ const TransactionsOfOneDay = ({
   const onDragOver = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    setDraggedIn(() => true);
-  };
-
-  const onDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
-    const elementBox = e.currentTarget.getBoundingClientRect();
-    const cursor = { clientX: e.clientX, clientY: e.clientY };
-
-    if (!cursorInElement(cursor, elementBox)) {
-      setDraggedIn(() => false);
-    }
+    setDraggedInDate(date);
   };
 
   const updateTransaction = async movedTransaction => {
@@ -48,24 +40,26 @@ const TransactionsOfOneDay = ({
     if (status !== 200) return alert('이동에 실패했습니다.');
 
     updateTransactionInStore(movedTransaction);
+    setDraggedInDate('');
   };
 
   const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const movedTransactionId = e.dataTransfer.getData('transactionId');
     const movedTransaction = getTransactionById(movedTransactionId);
-    setDraggedIn(false);
-    if (movedTransaction.date === date) return;
+
+    console.log('on drop');
+
+    if (draggedItem.date === date) return setDraggedInDate('');
     movedTransaction.date = date;
     updateTransaction(movedTransaction);
-    console.log('on drop:', movedTransactionId);
   };
 
   return useMemo(
     () => (
       <div
         className={`transactions__oneday__day${
-          draggedIn ? ' transactions__oneday__day__draggedIn' : ''
+          draggedInDate === date ? ' transactions__oneday__day__draggedIn' : ''
         }`}
         onDrop={onDrop}
         onDragOver={onDragOver}
@@ -85,9 +79,10 @@ const TransactionsOfOneDay = ({
               id={t._id}
               key={t._id}
               setDraggedItem={setDraggedItem}
+              setDraggedInDate={setDraggedInDate}
             />
           ))}
-          {draggedIn && draggedItem.date !== date && (
+          {draggedInDate === date && draggedItem?.date !== date && (
             <TransactionItem
               dragObject
               date={date}
@@ -102,7 +97,7 @@ const TransactionsOfOneDay = ({
         </ul>
       </div>
     ),
-    [transactions, draggedIn],
+    [transactions, draggedInDate],
   );
 };
 

--- a/FE/src/components/transaction/list/TransactionsOfOneDay/index.tsx
+++ b/FE/src/components/transaction/list/TransactionsOfOneDay/index.tsx
@@ -1,31 +1,108 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import './index.scss';
 
+import { useHistory } from 'react-router-dom';
 import TransactionItem from '../TransactionItem';
+import { useAccountBookData } from '../../../../store/AccountBook/accountBookInfoHook';
 import { iTransactionsOfOneDay } from '../../../../types/transaction';
+import { updateTransaction as updateTransactionApi } from '../../../../api/transaction';
+import cursorInElement from '../../../../util/calculate-cursor';
 
 const TransactionsOfOneDay = ({
   date,
   transactions,
+  draggedItem,
+  setDraggedItem,
 }: iTransactionsOfOneDay) => {
-  return (
-    <div className="transactions__oneday__day">
-      <div className="transactions__oneday__daybar">{date}일</div>
-      <div className="transactions__oneday__container">
-        {transactions.map(t => (
-          <TransactionItem
-            date={date}
-            category={t.category}
-            content={t.content}
-            payment={t.payment}
-            cost={t.cost}
-            type={t.type}
-            id={t._id}
-            key={t._id}
-          />
-        ))}
+  const [draggedIn, setDraggedIn] = useState(false);
+  const accountBookId = useHistory().location.state.id;
+
+  const { getTransactionById, updateTransactionInStore } = useAccountBookData(
+    store => ({
+      getTransactionById: store.getTransactionById,
+      updateTransactionInStore: store.updateTransaction,
+    }),
+  );
+
+  const onDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDraggedIn(() => true);
+  };
+
+  const onDragLeave = (e: React.DragEvent<HTMLDivElement>) => {
+    const elementBox = e.currentTarget.getBoundingClientRect();
+    const cursor = { clientX: e.clientX, clientY: e.clientY };
+
+    if (!cursorInElement(cursor, elementBox)) {
+      setDraggedIn(() => false);
+    }
+  };
+
+  const updateTransaction = async movedTransaction => {
+    const { status } = await updateTransactionApi(
+      accountBookId,
+      movedTransaction,
+    );
+
+    if (status !== 200) return alert('이동에 실패했습니다.');
+
+    updateTransactionInStore(movedTransaction);
+  };
+
+  const onDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const movedTransactionId = e.dataTransfer.getData('transactionId');
+    const movedTransaction = getTransactionById(movedTransactionId);
+    setDraggedIn(false);
+    if (movedTransaction.date === date) return;
+    movedTransaction.date = date;
+    updateTransaction(movedTransaction);
+    console.log('on drop:', movedTransactionId);
+  };
+
+  return useMemo(
+    () => (
+      <div
+        className={`transactions__oneday__day${
+          draggedIn ? ' transactions__oneday__day__draggedIn' : ''
+        }`}
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+      >
+        <label className="transactions__oneday__daybar">{date}일</label>
+        <ul className="transactions__oneday__container">
+          {transactions.map(t => (
+            <TransactionItem
+              dragObject={false}
+              date={date}
+              category={t.category}
+              content={t.content}
+              payment={t.payment}
+              cost={t.cost}
+              type={t.type}
+              id={t._id}
+              key={t._id}
+              setDraggedItem={setDraggedItem}
+            />
+          ))}
+          {draggedIn && draggedItem.date !== date && (
+            <TransactionItem
+              dragObject
+              date={date}
+              category={draggedItem.category}
+              content={draggedItem.content}
+              payment={draggedItem.payment}
+              cost={draggedItem.cost}
+              type={draggedItem.type}
+              id={draggedItem._id}
+            />
+          )}
+        </ul>
       </div>
-    </div>
+    ),
+    [transactions, draggedIn],
   );
 };
 

--- a/FE/src/components/transaction/list/transactions/index.tsx
+++ b/FE/src/components/transaction/list/transactions/index.tsx
@@ -13,6 +13,7 @@ const Transactions = ({
   selectedTypes: string[];
 }) => {
   const [draggedItem, setDraggedItem] = useState({});
+  const [draggedInDate, setDraggedInDate] = useState('');
 
   const {
     filteredTransactions,
@@ -42,6 +43,8 @@ const Transactions = ({
             key={day}
             draggedItem={draggedItem}
             setDraggedItem={setDraggedItem}
+            draggedInDate={draggedInDate}
+            setDraggedInDate={setDraggedInDate}
           />
         ))}
     </>

--- a/FE/src/components/transaction/list/transactions/index.tsx
+++ b/FE/src/components/transaction/list/transactions/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-one-expression-per-line */
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import TransactionsOfOneDay from '../TransactionsOfOneDay';
 import { useDateInfoData } from '../../../../store/DateInfo/dateInfoHook';
@@ -12,7 +12,8 @@ const Transactions = ({
   selectedCategories: string[];
   selectedTypes: string[];
 }) => {
-  // axios로 비동기 처리
+  const [draggedItem, setDraggedItem] = useState({});
+
   const {
     filteredTransactions,
     filterTransaction,
@@ -39,6 +40,8 @@ const Transactions = ({
             date={day}
             transactions={filteredTransactions[day]}
             key={day}
+            draggedItem={draggedItem}
+            setDraggedItem={setDraggedItem}
           />
         ))}
     </>

--- a/FE/src/store/AccountBook/accountBookData.ts
+++ b/FE/src/store/AccountBook/accountBookData.ts
@@ -20,6 +20,12 @@ export const createStore = () => {
 
     filteredPriceOut: 0,
 
+    getTransactionById(transactionId) {
+      return this.accountBook.transactions.find(
+        item => item._id === transactionId,
+      );
+    },
+
     addTransaction(transaction) {
       this.accountBook.transactions = [
         ...this.accountBook.transactions,
@@ -28,11 +34,14 @@ export const createStore = () => {
     },
 
     updateTransaction(transaction) {
-      const rest = this.accountBook.transactions.filter(
-        item => item._id !== transaction._id,
+      const newTransactions = [...this.accountBook.transactions];
+      const index = this.accountBook.transactions.findIndex(
+        item => item._id === transaction._id,
       );
 
-      this.accountBook.transactions = [...rest, transaction];
+      newTransactions.splice(index, 1, transaction);
+
+      this.accountBook.transactions = newTransactions;
     },
 
     deleteTransaction(id) {

--- a/FE/src/styles/values.scss
+++ b/FE/src/styles/values.scss
@@ -5,11 +5,13 @@ $selectedBoxShadow: -2px -2px 5px rgba(0, 0, 0, 0.5),
   3px 3px 3px rgba(255, 255, 255, 0.07);
 $selectedTextShadow: 0 0 10px rgba(33, 156, 243, 1),
   0 0 10px rgba(33, 156, 243, 1);
+$dragboxShadow: 0 0 10px rgb(236, 129, 97), 0 0 10px rgb(236, 129, 97);
 
 // color
 $black: black;
 $light-black: #222;
 $white: white;
+$transparent-color: rgba(255, 255, 255, 0);
 $little-white: #fff;
 $light-grey: lightgrey;
 $income-color: #54aafc;

--- a/FE/src/util/calculate-cursor.ts
+++ b/FE/src/util/calculate-cursor.ts
@@ -1,0 +1,16 @@
+export default function cursorInElement(cursor, element) {
+  if (
+    cursor.clientX <= element.x ||
+    cursor.clientX >= element.x + element.width
+  ) {
+    return false;
+  }
+  if (
+    cursor.clientY <= element.y ||
+    cursor.clientY >= element.y + element.height
+  ) {
+    return false;
+  }
+
+  return true;
+}


### PR DESCRIPTION
### 📕 Issue Number

Close #144
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

### 거래내역
![drag and drop](https://user-images.githubusercontent.com/46087226/102016490-a65d5f00-3da4-11eb-9b4a-c72673f1138d.gif)
- [x] 거래내역 아이템을 드래그
  - 드래그 된 아이템을 표시하는 스타일 추가
  - 드래그 된 아이템이 들어가는 날짜 컨테이너에 미리 아이템을 보여준다.
- [x] 거래내역 드랍
  - 거래내역 아이템이 들어간 날짜로 거래내역 정보를 수정한다.

### 거래내역 수정 모달창 수정
![image](https://user-images.githubusercontent.com/46087226/102016332-c3456280-3da3-11eb-9185-51f911599145.png)

- [x] 결제수단을 클릭했을 때 고유 색이 나오도록 수정
- [x] 카테고리를 클릭했을 때 지출이면 지출색, 수입이면 수입 색이 나오도록 수정
- [x] 가격 input이 추가될 때 천원마다 쉼표가 찍히도록 수정
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
