### PR TITLE
[BE] 연월별로 거래내역 읽어오는 API

### DIFF
--- a/BE/src/controllers/account-book.ts
+++ b/BE/src/controllers/account-book.ts
@@ -53,6 +53,14 @@ const getDetail = async (ctx: Context): Promise<Context['body']> => {
   return ctx.body;
 };
 
+const getTransactions = async (ctx: Context): Promise<Context['body']> => {
+  const accountBook = await service.getTransactions(ctx);
+  const res = response(200, 'success', accountBook);
+  ctx.status = res.status;
+  ctx.body = res;
+  return ctx.body;
+};
+
 const getCode = async (ctx: Context): Promise<Context['body']> => {
   const accountData = await service.getCode(ctx);
   const res = response(200, 'success', accountData);
@@ -61,4 +69,13 @@ const getCode = async (ctx: Context): Promise<Context['body']> => {
   return ctx.body;
 };
 
-export default { get, post, update, updateStartday, del, getDetail, getCode };
+export default {
+  get,
+  post,
+  update,
+  updateStartday,
+  del,
+  getTransactions,
+  getDetail,
+  getCode,
+};

--- a/BE/src/interfaces/transaction.ts
+++ b/BE/src/interfaces/transaction.ts
@@ -6,6 +6,6 @@ export default interface Transaction {
   type: string;
   category: { category: Category };
   cost: number;
-  date: string;
+  date: Date | string;
   payment: { payment: PaymentMethod };
 }

--- a/BE/src/interfaces/transaction.ts
+++ b/BE/src/interfaces/transaction.ts
@@ -6,6 +6,6 @@ export default interface Transaction {
   type: string;
   category: { category: Category };
   cost: number;
-  date: Date | string;
+  date: string;
   payment: { payment: PaymentMethod };
 }

--- a/BE/src/models/accountbook/index.ts
+++ b/BE/src/models/accountbook/index.ts
@@ -1,7 +1,9 @@
 import CategoryModel from '@models/category';
 import { User } from '@interfaces/auth';
 import AccountBook from '@interfaces/accountbook';
+import Transaction from '@interfaces/transaction';
 import { AccountBookDoc, AccountBookModel } from './schema';
+import { TransactionDoc } from '../transaction/schema';
 
 const get = async ({
   userid,
@@ -33,22 +35,38 @@ const getTransactions = async (
     .gte(`transactions.date`, new Date(`${year}-${month}-01`))
     .lte(`transactions.date`, new Date(`${year}-${month}-31`));
   if (accountBook) {
-    accountBook.transactions = accountBook.transactions.map<any>(
-      (transaction): any => {
-        const date = new Date(transaction.date);
-        const yyyy = date.getFullYear();
-        const mm = date.getMonth().toString().padStart(2, '0');
-        const dd = date.getDate().toString().padStart(2, '0');
-        const newdate = `${yyyy}-${mm}-${dd}`;
-        console.log(newdate);
-        transaction.date = transaction.date.toLocaleString().slice(0, 10);
-        console.log(transaction.date);
-
-        return transaction;
-      },
-    );
+    const transactions = accountBook.transactions.map(t => {
+      const { _id, content, type, category, cost, date, payment } = t;
+      const d = new Date(date);
+      const yyyy = d.getFullYear();
+      const mm = d.getMonth().toString().padStart(2, '0');
+      const dd = d.getDate().toString().padStart(2, '0');
+      const newdate = `${yyyy}-${mm}-${dd}`;
+      const ret = {
+        _id,
+        content,
+        type,
+        category,
+        cost,
+        date: newdate,
+        payment,
+      };
+      return ret;
+    });
+    const newAccountBook = {
+      _id: accountBook._id,
+      code: accountBook.code,
+      startday: accountBook.startday,
+      description: accountBook.description,
+      name: accountBook.name,
+      users: accountBook.users,
+      categories: accountBook.categories,
+      payments: accountBook.payments,
+      transactions,
+    };
+    console.log(newAccountBook);
+    return newAccountBook;
   }
-  return accountBook;
 };
 
 const create = async ({

--- a/BE/src/models/accountbook/index.ts
+++ b/BE/src/models/accountbook/index.ts
@@ -18,9 +18,36 @@ const get = async ({
 };
 
 const getDetail = async (id: string): Promise<any> => {
-  const accountBook = await AccountBookModel.findOne({
-    _id: id,
-  });
+  const accountBook = await AccountBookModel.findOne().where(`_id`).equals(id);
+  return accountBook;
+};
+
+const getTransactions = async (
+  id: string,
+  year: string,
+  month: string,
+): Promise<any> => {
+  const accountBook = await AccountBookModel.findOne()
+    .where('_id')
+    .equals(id)
+    .gte(`transactions.date`, new Date(`${year}-${month}-01`))
+    .lte(`transactions.date`, new Date(`${year}-${month}-31`));
+  if (accountBook) {
+    accountBook.transactions = accountBook.transactions.map<any>(
+      (transaction): any => {
+        const date = new Date(transaction.date);
+        const yyyy = date.getFullYear();
+        const mm = date.getMonth().toString().padStart(2, '0');
+        const dd = date.getDate().toString().padStart(2, '0');
+        const newdate = `${yyyy}-${mm}-${dd}`;
+        console.log(newdate);
+        transaction.date = transaction.date.toLocaleString().slice(0, 10);
+        console.log(transaction.date);
+
+        return transaction;
+      },
+    );
+  }
   return accountBook;
 };
 
@@ -356,4 +383,5 @@ export default {
   updateCode,
   addUser,
   delUser,
+  getTransactions,
 };

--- a/BE/src/models/accountbook/index.ts
+++ b/BE/src/models/accountbook/index.ts
@@ -302,12 +302,19 @@ const addUser = async (code: string, userInfo: any): Promise<any> => {
   const curAccountBook = await AccountBookModel.findOne({ code });
   if (curAccountBook) {
     const curUser = curAccountBook.users;
+    const id = curAccountBook._id;
     curUser.push(userInfo);
     const updateResult = await AccountBookModel.update(
       { code },
       { users: curUser },
     );
-    if (updateResult.nModified) return true;
+    if (updateResult.nModified) {
+      const accountBooks = await AccountBookModel.find(
+        { _id: id },
+        '_id name description',
+      );
+      return accountBooks;
+    }
     return false;
   }
   return false;

--- a/BE/src/models/transaction/schema.ts
+++ b/BE/src/models/transaction/schema.ts
@@ -6,21 +6,14 @@ import {
 } from '@models/paymentmethod/schema';
 import Transaction from '@interfaces/transaction';
 
-export interface TransactionDoc extends Transaction, mongoose.Document {
-  content: string;
-  type: string;
-  category: { category: CategoryDoc };
-  cost: number;
-  date: string;
-  payment: { payment: PaymentDoc };
-}
+export interface TransactionDoc extends Transaction, mongoose.Document {}
 
 export const Schema = new mongoose.Schema({
   content: { type: String, required: true },
   type: { type: String, required: true },
   cost: { type: Number, required: true },
   category: { type: CategorySchema, required: true },
-  date: { type: String, required: true },
+  date: { type: Date, required: true },
   payment: { type: PaymentSchema, required: true },
 });
 

--- a/BE/src/routes/api/account-book/index.ts
+++ b/BE/src/routes/api/account-book/index.ts
@@ -21,6 +21,10 @@ router.delete('/:accountbookid', controller.del);
 
 // GET accountbook detail
 router.get('/:accountbookid', controller.getDetail);
+router.get(
+  '/:accountbookid/year/:year/month/:month',
+  controller.getTransactions,
+);
 
 router.use('/:accountbookid/transaction', transactionRouter.routes());
 router.use('/:accountbookid/payment', paymentRouter.routes());

--- a/BE/src/routes/api/account-book/transaction.ts
+++ b/BE/src/routes/api/account-book/transaction.ts
@@ -8,6 +8,7 @@ const router = new Router();
 // api/accountbook/:accountbookid/transaction
 
 router.get('/csv', Controller.exportCSV);
+router.get('/year/:year/month/:month', Controller.exportCSV);
 router.post('/', Controller.post);
 router.post('/csv', Controller.importCSV);
 router.patch('/:transactionid', Controller.patch);

--- a/BE/src/services/account-book.ts
+++ b/BE/src/services/account-book.ts
@@ -87,7 +87,7 @@ const addUser = async (ctx: Context): Promise<any> => {
   const { code } = ctx.request.body;
   const userInfo = ctx.user;
   const updateResult = await accountBookModel.addUser(code, userInfo);
-  if (updateResult) return true;
+  if (updateResult) return updateResult;
   return false;
 };
 

--- a/BE/src/services/account-book.ts
+++ b/BE/src/services/account-book.ts
@@ -75,6 +75,15 @@ const getDetail = async (ctx: Context): Promise<any> => {
   return accountBook;
 };
 
+const getTransactions = async (ctx: Context): Promise<any> => {
+  const accountBook = await accountBookModel.getTransactions(
+    ctx.params.accountbookid,
+    ctx.params.year,
+    ctx.params.month,
+  );
+  return accountBook;
+};
+
 const getCode = async (ctx: Context): Promise<any> => {
   const id = ctx.params.accountbookid;
   const code = Random.randomStr(10);
@@ -109,4 +118,5 @@ export default {
   getCode,
   addUser,
   delUser,
+  getTransactions,
 };

--- a/BE/src/services/transaction.ts
+++ b/BE/src/services/transaction.ts
@@ -80,7 +80,7 @@ const exportCSV = async (ctx: Context): Promise<any> => {
   const accountBook = await accountBookModel.getDetail(
     ctx.params.accountbookid,
   );
-  const transactions = accountBook.transactions;
+  const { transactions } = accountBook;
   console.log(transactions);
 
   if (transactions) {

--- a/FE/src/components/AccountBook/AccountBookAddForm/JoinForm/index.tsx
+++ b/FE/src/components/AccountBook/AccountBookAddForm/JoinForm/index.tsx
@@ -9,8 +9,7 @@ export default function JoinForm({ setCreate, setDatas, setName }) {
       const res = await joinAccountBook({
         code: event.target.value,
       });
-
-      if (res.data === true) {
+      if (res.status === 200) {
         setCreate(false);
         setDatas([
           {


### PR DESCRIPTION
### 📕 Issue Number

<br/>

### 📙 작업 내역

> 연월별로 거래내역 읽어오는 API, JOIN API

- [x] 라우터
  - GET/ api/accountbook/:accountbookid/year/:year/month/:month
- [x] 컨트롤러
- [x] 서비스
- [x] 모델

- [x] join API 변경
  - FE 에서 res.status 로 if 처리
  - BE 에서 response 변경
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
