### PR TITLE
[FE, BE] template.csv 다운로드 구현

### DIFF
--- a/BE/src/controllers/transaction.ts
+++ b/BE/src/controllers/transaction.ts
@@ -10,6 +10,14 @@ const exportCSV = async (ctx: Context): Promise<Context['body']> => {
   return ctx.body;
 };
 
+const downloadTemplateCSV = async (ctx: Context): Promise<Context['body']> => {
+  const csv = await service.downloadTemplateCSV(ctx);
+  const res = response(200, csv.message, csv.data);
+  ctx.body = res;
+
+  return ctx.body;
+};
+
 const importCSV = async (ctx: Context): Promise<Context['body']> => {
   const csv = await service.importCSV(ctx);
   if (csv.message === 'success') {
@@ -42,4 +50,4 @@ const del = async (ctx: Context): Promise<Context['body']> => {
   return ctx.body;
 };
 
-export default { exportCSV, post, importCSV, patch, del };
+export default { exportCSV, downloadTemplateCSV, post, importCSV, patch, del };

--- a/BE/src/routes/api/account-book/transaction.ts
+++ b/BE/src/routes/api/account-book/transaction.ts
@@ -1,5 +1,4 @@
 import Router from 'koa-router';
-import koaBody from 'koa-body';
 
 import Controller from '@controllers/transaction';
 
@@ -10,6 +9,7 @@ const router = new Router();
 router.get('/csv', Controller.exportCSV);
 router.post('/', Controller.post);
 router.post('/csv', Controller.importCSV);
+router.get('/csv/template', Controller.downloadTemplateCSV);
 router.patch('/:transactionid', Controller.patch);
 router.delete('/:transactionid', Controller.del);
 

--- a/BE/src/services/transaction.ts
+++ b/BE/src/services/transaction.ts
@@ -108,6 +108,37 @@ const exportCSV = async (ctx: Context): Promise<any> => {
   };
 };
 
+const downloadTemplateCSV = async (ctx: Context): Promise<any> => {
+  const exampleTransaction = [
+    {
+      content: '버거킹',
+      type: '지출',
+      cost: 20000,
+      date: '2020-12-15',
+      category: { name: '식비', type: '지출' },
+      payment: { name: 'BC Card', desc: '체크 카드' },
+    },
+  ];
+
+  const fields = [
+    'content',
+    'type',
+    'cost',
+    'date',
+    'category.name',
+    'category.type',
+    'payment.name',
+    'payment.desc',
+  ];
+
+  const json2csvParser = new Parser({ fields });
+  const csv = json2csvParser.parse(exampleTransaction);
+  return {
+    message: 'success',
+    data: csv,
+  };
+};
+
 const importCSV = async (ctx: Context): Promise<any> => {
   const isValidForm = (tempTransaction: any) => {
     const requirementsFields = ['content', 'type', 'cost', 'date'];
@@ -175,4 +206,4 @@ const importCSV = async (ctx: Context): Promise<any> => {
   };
 };
 
-export default { post, patch, del, exportCSV, importCSV };
+export default { post, patch, del, exportCSV, downloadTemplateCSV, importCSV };

--- a/FE/public/template.csv
+++ b/FE/public/template.csv
@@ -1,0 +1,2 @@
+content,type,cost,date,category.name,category.type,payment.name,payment.desc
+버거킹,지출,20000,2020-12-15,식비,지출,BC Card,체크 카드

--- a/FE/src/api/csv.ts
+++ b/FE/src/api/csv.ts
@@ -16,3 +16,11 @@ export const postTransactionCSV = async (id, body) => {
 
   return data;
 };
+
+export const getTemplateCSV = id => {
+  const data = getFetch(
+    `${process.env.SERVER_URL}/api/accountbook/${id}/transaction/csv/template`,
+  );
+
+  return data;
+};

--- a/FE/src/components/SettingContent/CSVSetting/CSVExport/csvExport.scss
+++ b/FE/src/components/SettingContent/CSVSetting/CSVExport/csvExport.scss
@@ -13,5 +13,6 @@
   .csv__export__btn {
     display: flex;
     justify-content: center;
+    margin-bottom: 40px;
   }
 }

--- a/FE/src/components/SettingContent/CSVSetting/CSVExport/index.tsx
+++ b/FE/src/components/SettingContent/CSVSetting/CSVExport/index.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 import './csvExport.scss';
 import exportToCSV from '../../../../service/export';
 import ActionButton from '../../../Common/ActionButton';
-import { getTransactionCSV } from '../../../../api/csv';
+import { getTransactionCSV, getTemplateCSV } from '../../../../api/csv';
 import { ResponseMessage } from '../../../../util/message';
 
 export default function CSVExport({ accountBookId }) {
@@ -14,12 +15,24 @@ export default function CSVExport({ accountBookId }) {
         throw new Error();
       }
       const csv = res.data;
-      exportToCSV(csv);
+      exportToCSV(csv, 'transactions.csv');
     } catch (error) {
       throw new Error();
     }
   };
 
+  const downloadTemplateCSV = async () => {
+    try {
+      const res = await getTemplateCSV(accountBookId);
+      if (res.status !== ResponseMessage.success) {
+        throw new Error();
+      }
+      const csv = res.data;
+      exportToCSV(csv, 'template.csv');
+    } catch (error) {
+      throw new Error();
+    }
+  };
   return (
     <div className="csv__export__box">
       <div className="csv__export__title">Export</div>
@@ -28,6 +41,14 @@ export default function CSVExport({ accountBookId }) {
       </div>
       <div className="csv__export__btn">
         <ActionButton content="Export" action={downloadCSV} type="general" />
+      </div>
+      <div className="csv__export__desc">You can download Template.csv</div>
+      <div className="csv__export__btn">
+        <ActionButton
+          content="Download"
+          action={downloadTemplateCSV}
+          type="general"
+        />
       </div>
     </div>
   );

--- a/FE/src/service/export.ts
+++ b/FE/src/service/export.ts
@@ -1,6 +1,5 @@
-export default function exportToCSV(csv) {
+export default function exportToCSV(csv, filename) {
   const downloadFile = link => {
-    const filename = 'transactions.csv';
     const a = document.createElement('a');
     a.setAttribute('target', '_blank');
     a.setAttribute('style', 'display:none');

--- a/FE/src/styles/mixins.scss
+++ b/FE/src/styles/mixins.scss
@@ -33,6 +33,7 @@
   height: 30px;
   background-color: $modal-button-background;
   font-size: 1em;
+  padding: 0px;
 
   &:hover {
     background-color: $light-black;

--- a/FE/webpack.config.js
+++ b/FE/webpack.config.js
@@ -61,9 +61,9 @@ module.exports = {
   },
   devtool: 'eval-source-map',
   devServer: {
-    contentBase: path.join(__dirname, 'dist'),
+    contentBase: path.join(__dirname, 'public/'),
     historyApiFallback: true,
-    host: '127.0.0.1'
+    host: '127.0.0.1',
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.scss'],


### PR DESCRIPTION


### 📕 Issue Number

Close #101 
<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] template.csv는 transaction 필드와 예시가 1개 있는 파일이다.
- [x] template.csv 파일을 다운받기 위한 api와 FE에서는 버튼을 새로 생성하였다.
- [x] FE에서 바로 다운받을 수 있게 하고 싶었지만 public의 local파일을 쓰는 건 webpack의 dev-server 용도라 production용으로는 적합하지 않다고 판단하였다.
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
