### PR TITLE
[FE] 거래내역 안의 스크롤을 밖으로 분리

### DIFF
--- a/FE/src/components/Common/MenuBar/menubar.scss
+++ b/FE/src/components/Common/MenuBar/menubar.scss
@@ -4,7 +4,8 @@
 
 .menubar__header {
   @include headerSetting;
-  position: relative;
+  position: sticky;
+  top: 0%;
 
   &.light {
     background-color: $light-background-color;

--- a/FE/src/components/transaction/list/filter/listfilter.scss
+++ b/FE/src/components/transaction/list/filter/listfilter.scss
@@ -2,7 +2,7 @@
 
 .acbook__filter__container {
   width: 100%;
-  // height: 25%;
+  min-height: 60%;
   padding: 3em 0;
   display: flex;
   flex-direction: column;

--- a/FE/src/components/transaction/list/listcontainer.scss
+++ b/FE/src/components/transaction/list/listcontainer.scss
@@ -4,17 +4,15 @@
 .transaction__list__container {
   width: 60%;
   height: 100%;
-
   background-color: $dark-background-color;
 
   display: flex;
   flex-direction: column;
   align-items: center;
 
-  overflow-y: scroll;
   overflow-x: hidden;
+  overflow-y: visible;
   position: relative;
-  padding-bottom: 5em;
   gap: 1.5em;
 
   &.light {
@@ -25,7 +23,7 @@
 .transaction__add__button {
   @include buttonDefaultSetting;
   position: sticky;
-  bottom: -8%;
+  bottom: 5%;
   right: 0;
 
   background-color: transparent;

--- a/FE/src/pages/transaction/transaction.scss
+++ b/FE/src/pages/transaction/transaction.scss
@@ -1,11 +1,9 @@
 @use '../../styles/values.scss' as *;
 
 .transaction__container {
-  height: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  overflow-y: auto;
   background-color: $dark-background-color;
   &.light {
     background-color: white;


### PR DESCRIPTION
### 📕 Issue Number


<br/>

### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 스크롤바가 거래내역 컨테이너 안에 나오는 것을 밖에 창에서 스크롤 할 수 있도록 수정
<br/>

### 멘토님 멘셔닝

@boostcamp-2020/accountbook_mentor
<br/>
